### PR TITLE
fix: plots use consistent colors across reports

### DIFF
--- a/reports/report.ipynb
+++ b/reports/report.ipynb
@@ -58,7 +58,9 @@
     "END_MONTH_DAY = friendly_date(END_DATE)\n",
     "\n",
     "WEEK_MARKERS = pd.date_range(START_DATE, END_DATE, freq=\"W\").astype(str).tolist()\n",
-    "BIWEEKLY_MARKERS = pd.date_range(START_DATE, END_DATE, freq=\"2W\").astype(str).tolist()"
+    "BIWEEKLY_MARKERS = pd.date_range(START_DATE, END_DATE, freq=\"2W\").astype(str).tolist()\n",
+    "\n",
+    "CHANGE_PLOT_BREAKS = [\"Added\", \"Removed\", \"Unchanged\"]"
    ]
   },
   {
@@ -317,7 +319,7 @@
     "\n",
     "from pathlib import Path\n",
     "\n",
-    "out_dir = Path(f\"output/{CALITP_ITP_ID}_{CALITP_URL_NUMBER}/data\")\n",
+    "out_dir = Path(f\"outputs/{CALITP_ITP_ID}/data\")\n",
     "out_dir.mkdir(parents=True, exist_ok=True)\n",
     "\n",
     "json.dump(feed_info, open(out_dir / \"1_feed_info.json\", \"w\"))\n",
@@ -423,7 +425,7 @@
     "    + theme(axis_text_x=element_text(angle=45, hjust=1))\n",
     "    + scale_x_datetime(date_breaks=\"1 week\")\n",
     "    + expand_limits(y=0)\n",
-    "    + labs(y = \"Total service hours\", x = \"Service date\", title=\"Service hour per day\")\n",
+    "    + labs(y = \"Total service hours\", x = \"Service date\", title=\"Service hours per day\")\n",
     ").draw();"
    ]
   },
@@ -432,6 +434,16 @@
    "metadata": {},
    "source": [
     "## Changes Since Previous Month"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mizani import palettes\n",
+    "palettes.hls_palette(n_colors=3)"
    ]
   },
   {
@@ -449,6 +461,7 @@
     "    )\n",
     "    >> ggplot(aes(\"kind\", \"n\", fill=\"status\"))\n",
     "    + geom_col()\n",
+    "    + scale_fill_discrete(limits = CHANGE_PLOT_BREAKS)\n",
     "    + labs(\n",
     "        x=\"GTFS schedule table\",\n",
     "        y=\"Number of IDs\",\n",
@@ -479,6 +492,7 @@
     "    )\n",
     "    >> ggplot(aes(\"kind\", \"percent\", fill=\"status\"))\n",
     "    + geom_col()\n",
+    "    + scale_fill_discrete(limits=CHANGE_PLOT_BREAKS)\n",
     "    + labs(\n",
     "        x=\"GTFS schedule table\",\n",
     "        y=\"Percentage of IDs\",\n",

--- a/reports/report.ipynb
+++ b/reports/report.ipynb
@@ -442,16 +442,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from mizani import palettes\n",
-    "palettes.hls_palette(n_colors=3)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "(\n",
     "    pd.concat(\n",
     "        [\n",


### PR DESCRIPTION
This change puts all color levels on plots, even if they don't have values for a level.

![image](https://user-images.githubusercontent.com/2574498/123688136-ae9c5980-d81f-11eb-9c6c-824042c0d553.png)
