### PR TITLE
feat(content): add privacy policy link to bottom

### DIFF
--- a/templates/index.html.jinja
+++ b/templates/index.html.jinja
@@ -162,6 +162,10 @@
                 but doesn’t have it, or have related questions, you can contact the Helpdesk to
                 take advantage of our available technical services.
             </p>
+
+            <p>
+                <a href="https://dot.ca.gov/privacy-policy">Privacy Policy></a>
+            </p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
I don't know how barbaric this is stylewise, but I just put the link at the very bottom. We could throw it in the footer down the road :).

![image](https://user-images.githubusercontent.com/2574498/124985605-9939e300-e008-11eb-86e9-34a4ee50745b.png)
