### PR TITLE
Reports email script

### DIFF
--- a/reports/report.ipynb
+++ b/reports/report.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "source": [
     "import pandas as pd\n",
     "import numpy as np\n",
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "source": [
     "DIR_PATH=\"2021/05/106\"\n",
     "\n",
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "source": [
     "DATE_TODAY=date.today()\n",
     "START_MONTH_DAY = friendly_date(DATE_START)\n",
@@ -80,7 +80,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "source": [
     "if not DEBUG:\n",
     "    warnings.filterwarnings(\"ignore\")"
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "source": [
     "# Convenience functions ----\n",
     "\n",
@@ -112,10 +112,20 @@
     "    _.calitp_itp_id == CALITP_ITP_ID, _.calitp_url_number == CALITP_URL_NUMBER\n",
     ")\n",
     "\n",
-    "collect_to_dict = (\n",
-    "    collect()\n",
-    "    >> pipe(_.to_dict(orient=\"records\")[0])\n",
-    ")\n",
+    "def collect_to_dict(df):\n",
+    "    \"\"\"Return the first row of a DataFrame as a dictionary.\n",
+    "    \n",
+    "    If there are no rows, then all dictionary values are None.\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    result = collect(df)\n",
+    "    \n",
+    "    if len(result) == 0:\n",
+    "        return {k: None for k in result.columns}\n",
+    "    elif len(result) > 1:\n",
+    "        raise ValueError(\"table contained more than 1 row\")\n",
+    "    else:\n",
+    "        return result.iloc[0,:].to_dict()\n",
     "\n",
     "\n",
     "select_rm_calitp = select(\n",
@@ -171,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "source": [
     "# Data ====\n",
     "# 1. High level feed info ----\n",
@@ -180,7 +190,7 @@
     "    >> filter_end\n",
     "    >> filter_itp\n",
     "    >> select_rm_calitp\n",
-    "    >> collect_to_dict\n",
+    "    >> pipe(collect_to_dict)\n",
     ")\n",
     "\n",
     "_n_routes = (\n",
@@ -201,7 +211,7 @@
     "    >> filter(_.calitp_itp_id == CALITP_ITP_ID, _.calitp_url_number == CALITP_URL_NUMBER)\n",
     "    >> filter_end    \n",
     "    >> select(_.calitp_agency_name, _.gtfs_schedule_url == _.calitp_gtfs_schedule_url)\n",
-    "    >> collect_to_dict\n",
+    "    >> pipe(collect_to_dict)\n",
     ")\n",
     "\n",
     "# 2. Monthly metrics ----\n",
@@ -270,7 +280,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "source": [
     "# 4. Feed files being checked for ----\n",
     "\n",
@@ -363,7 +373,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "source": [
     "def apply_codes(df, code_funcs):\n",
     "    code = df.code.unique()[0]\n",
@@ -399,7 +409,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "source": [
     "tbl_code_descriptions = (\n",
     "    tbl.views.validation_code_descriptions()\n",
@@ -435,7 +445,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "source": [
     "# Note that everything is saved in this cell, except for plots,\n",
     "# which are saved in the cell they're defined in\n",
@@ -490,7 +500,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "source": [
     "from IPython.display import Markdown\n",
     "\n",
@@ -500,7 +510,24 @@
     "Date generated: {DATE_TODAY}\n",
     "\"\"\")"
    ],
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ],
+      "text/markdown": [
+       "\n",
+       "Transit provider name: None\n",
+       "\n",
+       "Date generated: 2021-11-24\n"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 11
+    }
+   ],
    "metadata": {}
   },
   {
@@ -519,7 +546,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "source": [
     "Markdown(f\"\"\"\n",
     "Feed location: {status[\"gtfs_schedule_url\"]}\n",
@@ -531,7 +558,28 @@
     "* Number of stops in service: {feed_info[\"n_stops\"]}\n",
     "\"\"\")"
    ],
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ],
+      "text/markdown": [
+       "\n",
+       "Feed location: http://iportal.sacrt.com/gtfs/FSL/google_transit.zip\n",
+       "\n",
+       "Metrics for the most recent published version of the feed:\n",
+       "\n",
+       "* Date published: None\n",
+       "* Number of routes in any service: 3\n",
+       "* Number of stops in service: 130\n"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 12
+    }
+   ],
    "metadata": {}
   },
   {
@@ -543,7 +591,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "source": [
     "# TODO: \n",
     "\n",
@@ -555,12 +603,27 @@
     "Days with no service hours: {n_expired_days[\"n\"]}\n",
     "\"\"\")\n"
    ],
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ],
+      "text/markdown": [
+       "\n",
+       "Days with no service hours: 31\n"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 13
+    }
+   ],
    "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "source": [
     "p = (\n",
     "    tbl_daily_service_hours\n",
@@ -583,7 +646,20 @@
     "\n",
     "p.draw();"
    ],
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ],
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmwAAAIWCAYAAADqLNGCAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8/fFQqAAAACXBIWXMAAA9hAAAPYQGoP6dpAABYuUlEQVR4nO3dd5glRb3w8W/t7GxkYcmwZFCQICA5C64BBcoIV0VBRfTqNevrlXv1Ys5Z0WvGgIoiapkjCILkIKCIlyi7IAsusCwbZmfr/aP6wOEw4cyZ1DPz/TzPec5Md1d3nanp7t+prhByzkiSJKm+po13BiRJkjQwAzZJkqSaM2CTJEmqOQM2SZKkmjNgkyRJqjkDNkmSpJozYJMkSao5AzZJkqSaM2CTJEmqOQM2SZKkmps+3hkYbTHGacDrgVcC2wF3Ad8FTk0pPThI2sOBc/pZfUZK6UV9pDkBeBPwOOBeIAGnpJTu6fAjSJKkKW4q1LB9Avg48BfgNcD3gTcAP44xhjb38UXgxS2vz7VuFGN8I/B1SqD2uirdC4FzYoxzhvMhJEnS1DWpa9hijLsCrwXOTik9t2n5zcCngWOB77Wxqz+llL41yLE2At4LXAosTCn1VssvpdSyvQb4cCefQ5IkTW2TvYbtBUAAPtmy/EvAg8CjHmn2J8Y4N8Y4c4BNngXMAT7TCNYAUko/AW4ayrEkSZKaTfaAbV9gLXBJ88KU0krgqmp9Oz4NPACsjDFeH2N8dT/HAvhTH+suAnaNMc5u83iSJEkPmewB2wLg7pTSqj7WLQI2izF2DZC+h/I48/8BEXg1sAI4Lcb46T6O1dhvX8eaBmw+hLxLkiQBk7wNG+URZV/BGsDK6n02pfbsUVJKFwDPbF4WY/wicC7w2hjjl1JK1zQdi36Ot7JlG0mSpLZN9hq2B4H+2p3Nqt5XDGWHVfu0D1a/Pr3lWPRzvFkt20iSJLVtstewLQZ2iTHO7OOx6BbAnc0dBIbglup9o5ZjNfb7f30cay1wRwfHasvixYvfCZw6WvuXJEkjb8GCBW0NMTbZA7ZLgacC+wHnNxbGGGcBewK/73C/j63e/9lyrFcAB/LogO0A4C8ppSHV5g3RByjjzQ3J/Pnz9+jq6jqvt7f3sHvvvffqUcjXeJgH3A5sCSwb57wMm2U0MUzCcrKMJoZJVU6WUf8me8B2JvBflIFyz29afjKlPdkZjQUxxh2A7pTS9U3LNmydoaDq6fkOSo3Zz5pW/ZjSm/Q1McZvN43DdgywPXDKyH2sR1uwYMEq+m+v16+enp7lANOmTVu+YMGC+0c8Y+Ng8eJGZSfLJsNnsowmhslWTpbRxDDZysky6t+kDthSStfEGE+jBFFnAz8HdqbMQvB7SkDX8DtgG8q4bQ2/jDEuAq6gPPLcEjiBMsXVe5qDu5TSkhjjO4CPAr+NMX6H8ij0zcB1lGBOkiRpyCZ7pwMotWtvAXYFTgP+DfgUEFNKeZC0ZwGbUmZL+DxlTtKbgGenlP6ndeOU0seAlwIbUAK0V1HmLT1isHlLJUmS+jOpa9jgoV6dH6teA223bR/LPgR8aIjHOx04fShpJEmSBjIVatgkSZImNAM2SZKkmjNgkyRJqjkDNkmSpJozYJMkSao5AzZJkqSaM2CTJEmqOQM2SZKkmjNgkyRJqjkDNkmSpJozYJMkSao5AzZJkqSaM2CTJEmqOQM2SZKkmjNgkyRJqjkDNkmSpJozYJMkSao5AzZJkqSaM2CTJEmqOQM2SZKkmjNgkyRJqjkDNkmSpJozYJMkSao5AzZJkqSaM2CTJEmqOQM2SZKkmjNgkyRJqjkDNkmSpJozYJMkSao5AzZJkqSaM2CTJEmqOQM2SZKkmjNgkyRJqjkDNkmSpJozYJMkSao5AzZJkqSaM2CTJEmqOQM2SZKkmjNgkyRJqrnp450BjYyenp7Ngc07SPq4xntPT88I5mj8rL/++nOXLVvGvHnz9ujp6Vk+3vkZAZbRxDCpyskymhgmYTlNuTLq7u6+op39hJzzyOdOY66np+edwKnjnQ9JktS+7u7u0M52BmyTxDBr2M4AjgeuH9FMjZM1a9bMXbZs2Xnz5s07bPr06ZPlG6dlVH+Tqpwso4lhEpbTlCujdmvYfCQ6SXR3d98B3DHUdE1Vzte3+09Td0uWLFkXYOnSpVcvWLDg/vHOz3BZRhPDZCsny2himGzlZBn1z04HkiRJNWfAJkmSVHMGbJIkSTVnwCZJklRzBmySJEk1Z8AmSZJUcwZskiRJNWfAJkmSVHMGbJIkSTVnwCZJklRzBmySJEk1Z8AmSZJUcwZskiRJNWfAJkmSVHMGbJIkSTVnwCZJklRzBmySJEk1Z8AmSZJUcwZskiRJNWfAJkmSVHMGbJIkSTVnwCZJklRzBmySJEk1Z8AmSZJUcwZskiRJNWfAJkmSVHMGbJIkSTVnwCZJklRzBmySJEk1Z8AmSZJUcwZskiRJNddRwBZCmB9C2D2EsH7L8k1DCF8LIVwZQvhhCGH3kcmmJEnS1NVpDdspwJXAdo0FIYRu4I/ACcAewDOBc0IIC4abSUmSpKms04DtCODWnPMVTcuOBXYA/gQ8C/gKsD7w6uFkUJIkaarrNGDbCvh7y7KjgQy8LOeccs4nA7cCRw0jf5IkSVPe9A7TbQAsaVl2IHBTzvmGpmVXAE/s8BgjIsY4DXg98ErKI9y7gO8Cp6aUHhwk7eHAvwGHAVsDy4G/Ah9NKf2sj+1zP7talFLastPPIEmSprZOa9hWAfMbv4QQNgO2obRha7YCmN3hMUbKJ4CPA38BXgN8H3gD8OMYYxgk7QcpNYS/Ad4IfBTYBPhpjPEd/aQ5H3hxy+u1w/sIkiRpKuu0hu0G4OAQwpyc84PAcyiPQ1sDtgWUGq1xEWPclRIsnZ1Sem7T8puBT1Pa3X1vgF28FbggpdTblPY0SoeLd8QYP5tSWtqS5qaU0rdG6jNIkiR1WsN2JrAe8IcQwicoNVGrgNTYIIQwHdiLR7d1G0svAALwyZblXwIeBF40UOKU0nnNwVq1bAXwM6Ab2KmvdDHGGTHGdTrMsyRJ0iN0GrB9Cvg9sDelfdhs4P/lnJvbtT0FWJfyiHC87AusBS5pXphSWglcVa3vRKM9Wms7Pii1diuAZTHGO2OMHzd4kyRJw9FRwJZzXk0JyJ4IHAfslHM+rWWzlZR2X+P5eHABcHdKaVUf6xYBm8UYu4aywxjj7sCzgYtSSje2rL4EOJXyiPglwAWUv8HvY4yzhph3SZIkoMM2bCGEw4DenHO/tWc553OAczrN2AiZQ3lU25eV1fts4IF2dhZjXB84C+gBXt66PqW0f8uir8cY308ZaPhk4DPtHEeSJKlZp50Ozq1eTxqxnIyOBym9OvvSqPFa0c6OYozzgF9QesM+K6V0XZt5eD/wNuDpjGLAtnjx4pnAzKGmmz9//tyuri56e3vnLlmyZN1RyNp4mNd4X7x48bhmZCRYRhPDJCwny2himFTlNBXLaMGCBfe3s5NOA7alwET4z1gM7BJjnNnHY9EtgDtbOxX0JcY4l9LRYG/guJTSL9rNQErpgRjjPcBGQ8h3J06hPI4dknvvvbfx43kjmZmauH28MzASLKOJYRKXk2U0MUyKcpqiZTTYEGNA5wHbVcBjO0w7li4FngrsR1Pnh6o92Z6UjhMDijHOBn4KHAS8MKX0w6FkIMY4nxKsXTSUdB34AGW8uSGZP3/+Hl1dXef19vYedu+99149CvkaD/MoJ8aWwLJxzsuwWUYTwyQsJ8toYphU5WQZ9a/TgO3TwA9DCEflnB814n+NnAn8F2Wg3Ob2didT2red0VgQY9wB6E4pXd+0bBZlqJLDgBNSSv2O2RZj3DCldE8fq95fvf+kw8/QlgULFqyi//Z6/erp6VkOMG3atOXtVsvWXVOV87LJ8Jkso4lhspWTZTQxTLZysoz612nAdiXwWUrQdjrwA+AW+mkPlnO+rcPjDEtK6ZpqoNvXxBjPBn4O7Ay8jlK7dmbT5r+jtE9rrpo8A3hylS7EGFvHbbswpXRT9fPbY4z7U9r23UoZp+5o4NBq318bwY8mSZKmkE4Dtpur9wCcVL36k4dxnJHwBkow+QrKNFNLKOPInZpS6m/uz4a9q/dnVK9WLwUaAdu5wC7AiZRHoGuA64G3AJ9OKfV0+gEkSdLU1mkg9Q9KIFZ7VaeCj1Wvgbbbtp1lA6T/MfDjIWZPkiRpUB0FbDnnbUc4H5IkSepHp1NTSZIkaYwYsEmSJNVcp1NTbT2U7cerl6gkSdJk0Gmng1tov9PBePcSlSRJmtA6DaRuo++AbRqwedN+b+1w/5IkSaqMeC/REMJ04EjKROfn5Jxf1lnWJEmSBKPwqDLnvAb4aQjhH8AlIYSLcs5fHOnjSJIkTRWj1ks053w1cBnw76N1DEmSpKlgtIf1WATsOMrHkCRJmtRGLWALIQRgd8A5NCVJkoZhVAK2EMJGwOeBxwIXjcYxJEmSpopOB869aYDV84ANgACsBk7t5BiSJEkqOu0luu0g61cD5wFvzzlf0uExJEmSROcB23YDrFsNLKmG95AkSdIwdTpwrjMYSJIkjZHRHtZDkiRJwzSsmQ6qaaieBxwBbFEtXgScA5zlY1FJkqTh6zhgCyHsCZxFac8WWla/HHhPCOHYnPNVHedOkiRJHQ/rsQD4NbAR8E/gu8CN1ertgecDOwC/CiHsmXO+YwTyKkmSNCV1WsP2n5Rg7cvA63POK5pXhhD+C/g0pabtrcAbh5NJSZKkqazTTgdPB24DXtUarAHknFcCr662Oarz7EmSJKnTgG0r4MKcc29/G1QdDv5UbStJkqQOdRqwrQLWbWO7edW2kiRJ6lCnAdtfgCNCCP3WnoUQtqYM93Fdh8eQJEkSnQds3wBmA78NITyjdWUI4WjgN8CsaltJkiR1qNNeol8CngssBH4SQvgXcHO1bjtgA8rYbL+ttpUkSVKHOqphqzobHAV8GFgObAjsU702rJZ9CDg657x2ZLIqSZI0NXU800HOeTXwthDCqZRArXlqqstyznY2kCRJGgHDmksUoArMLhiBvEiSJKkPnXY6kCRJ0hgZVg1bNafoEZTHobP62SznnN8znONIkiRNZR0HbCGEjwOvAboai1o2ydWyDBiwSZIkdaijgC2E8CbgDZRg7FfAX4H7Ry5bkiRJaui0hu0kYA3w1JzzuSOXHUmSJLXqtNPBDsAfDdYkSZJGX6cB2zLgjpHMiCRJkvrWacB2PrDHSGZEkiRJfes0YHs38JgQwstHMjOSJEl6tLY6HYQQDutj8ceBL4QQngr8FLgN6HPe0JzzeR3nUG3p6enZHNi8g6SPa7z39PSMYI7Gz/rrrz932bJlzJs3b4+enp7l452fEWAZTQyTqpwso4lhEpbTlCuj7u7uK9rZT8g5D75RCGspQ3g8alU/y5vlnPOwp8DSwHp6et4JnDre+ZAkSe3r7u5uHce2T+0GUucxeGCm8fUFIHWQ7nHAGcDxwPUjmqNxsmbNmrnLli07b968eYdNnz59snzjtIzqb1KVk2U0MUzCcrKM+tFWwJZzPrzTA2hsdHd330EHPXebqpyvb7datu6WLFmyLsDSpUuvXrBgwYQf0NkymhgmWzlZRhPDZCsny6h/Tv4uSZJUcwZskiRJNWfAJkmSVHMGbJIkSTVnwCZJklRzBmySJEk1Z8AmSZJUcwZskiRJNWfAJkmSVHPDCthCCIeGEL4XQrg9hLAqhPCVpnVPCSG8P4Sw2fCzKUmSNHV1HLCFEN4OnAs8D1gAdFMmg2+4D/hP4DnDyJ8kSdKU11HAFkJ4OvBuYBFwHLBp6zY550uAJcDRw8mgJEnSVNfW5O99eD2wCnh6zvk6gBBCX9tdDTy2w2NIkiSJzh+J7gtc0gjWBrAEsA2bJEnSMHQasM0F7mxju/WGcQxJkiTReTD1T+AxbWy3E/CPDo8hSZIkOg/Y/gjsGUI4uL8NQghHU4K6czo8hiRJkug8YPsYkIGzQwjPCiE8ovNCCOFI4MtAD/CZ4WVRkiRpausoYMs5XwG8GdgI+AFwLyWAe24I4V7gZ8AmwJtzzn8ZkZxKkiRNUR13CMg5fwp4BnApMJsyaO48YF3gGiDmnD87EpmUJEmayjodhw2AnPOvgF+FEDYEtqMEgP/IOd8xEpmTJEnSMAO2hpzzPcA9I7EvSZIkPVKnU1PNDCFsHUKYN8A286ptZnSePUmSJHXahu31wM3APgNss0+1zX90eAxJkiTRecB2DLAo59zvGGvVusXAMzs8hiRJkug8YHsM0M5wHdfh5O+SJEnD0mnAtgFwdxvb3Q1s2OExJEmSROcB278ow3gMZjvg/g6PIUmSJDoP2C4H9gsh7NbfBiGEXYH9q20lSZLUoU4Dtq8CXcCPQgh7tq6slv2YMvvB6R0eQ5IkSXQ4cG7O+ewQwg+BZwOXhxAuB66vVj8O2JsSrP0453zmiORUkiRpihrOTAf/BnyIMs7aPjxyTLbVwOeBtw5j/5IkSWIYAVvOeQ3w5hDCB4EjgG2qVbcBv885LxmB/EmSJE15w55LtArMvjcCeZEkSVIfOu10IEmSpDHSVg1bCGHr6sdFOefept/bknO+bcg5kyRJEtD+I9FbgLXALsAN1e+5zbR5CMeZ8GKM04DXA6+kDBx8F/Bd4NSU0oPjmTdJkjQxtRtI3UYJvHpaftejfQJ4HfBD4GPAzsAbgD1jjE9NKfl3kyRJQ9JWwJZz3nag31XEGHcFXgucnVJ6btPym4FPA8diBw1JkjREdjoYWS+gDBj8yZblXwIeBF401hmSJEkTX0dty0IIj885XzPSmZkE9qW09bukeWFKaWWM8apq/YQRQjgcOBS4H/huzvmfQ0h7CHA4sLxKe8cQ0h4IPAlYAXwv53z7ENLut8466xz9xje+kT/+8Y9b/f73v79uCGn3Bp5GGfj57JzzTUNIuyfwdGAN8KOc89+HkPbxwFGU/52Uc75+kCTNaXcGYvXrT3POQ/m8OwLPonxx+3nO+c9DSLsD8BzKNeSXOecrh5B2u3XXXfeFr3rVq/jxj3/8hL/+9a9/GELarSk11bOA3+WcLxpC2i0oA37PAc7JOV8whLSbAc8H5gF/yDmfN4S0m1C+zK0L/DHnfM4Q0m4IHA/MB/6Uc/7NENKuX6XdALgk5/zLIaRdb/78+SeddNJJfOc733nqokWLzhpC2nmUL6ebAFdR/qfbagoSQphbpd0MuAb44RDSzq7SbgFcB5w1hLQzq7RbUWbt+V7OeW2baWdQ/s7bAH+nXO9620zbTfnf2B64EfhONcZpO2m7gBfMnTt31/e85z1svvnm05///Oe3k5QQwjTKubATpYnTt3LOq4eQ9nmU5j6LqrQr20wbKNeN3YA7qrRtte2u0j4T2AP4Z5X2gSGkPRrYC1gCfDPnvKydtFX6Z1AmB7gHOCPnfG+7aUdUznnIL6CXEpS8CpjfyT4m4+uYY4655phjjvlnP+u+d8wxx+Rjjjmma7zz2fxavXr1XqtXr86rV6/eq6WM30IJIFYAK4G7gR3a/P94TUvapcDj2kz7ipa09wG7tZn2xOp/c+WMGTMy8ACwV5tpn1+lbRz3QWD/NtM+hxKoNdKuAA5tM+3RlLahjbSrgCe1WUZPpQSXjbSrgSPbPO7hVZpGfnuAZ7aZ9qCWz9oLHNtm2n0pQfzKmTNn5irt8W2m3YPy5aH5uC9rM+0uwL1NadcCr2oz7Y6UC3Vz2te3cy7xcMej5rRvbfO4W1Fuas2f99Q2024O3N6S9gNtpt2Y0rFsVVMZfaLNtBsA/1f9H6+ozov/bTPtesBfW9KeDoQ20q4D/LkpbQ+ls9cj0vZTRrOBy5vOpR5KG+RpbRx3JnBhS9pfAINe54Fu4NymtKuB3wHT20g7Hfh1lWZld3d37urquhCY0UbaLuAnPHzdWQ1cDMxqI+004KymtKuAK4E5baQNwBktaa8F5rVRRgH4Mg9fZ1cBf6PN+AP4bEvam4AN20z7UR6+N6yiBLibtpO28Vq0aNG6ixYtyosWLVp3KOkelZeOEsGd1YWnl3Jj+zbwlOFkZDK8jjnmmBuPOeaY2/pZ940qYFtnvPPZ/Orn5Ni6Kt/c9FoN/KKN/43Nqv+L5rQ9wLltpN2gOqma066h1CwMlnZedTK1pr2qjbSzqpOxOW0vcH0baadTApDWtDe3kTZQgojmtGuBxYOVUZX+rj7K6R7au8H9oyXtWkow1M5N6v/6KOPltHezuLaPtKvavOBf1sf/Rw+wXhtp/1ht2/r/sXEbaX/bR9q1wBZtnEs/qc6d1rTbtXHc7/WRNgM7tZH2G/0cd4820n6hj3NpLbBfG2k/0UfaXuCwNtJ+oJ+0g95bgHf2kXYNcEwbZfS2PtL20MaXEEqHsta0q4EXt5H23/tJ+/I20r60j/JdBbymjbQv6CftW9pI++w+zoVVwNvbSNt4AtGa9j1tlNGT6Pu68ZE2jnsQj75OrgI+20bavfs4/1YBXxksbfNrpAK2Tofb2AJ4RvVPcxSlduLfQgiLKN+Ivp5zvrHDfU9kD1IeA/RlVvW+YjQOvHjx4pmUb3tDMn/+/LldXV309vbOXbJkyboA22yzze633npr66bdIYTdFy5cuMtA+9t00033/Oc//9naNnJ6CGHXwdIuWLBg58WLF3e1LO4Cdhks7dZbb73DbbfdNqOPtDsOlna77bbb6uabb57VsngasMNgaXfcccdNbrjhhjl9pN3miU984q7Tp0/P/aXdbbfd1rv22mvXa1kcgM0PPPDAPebMmdMDcPzxx2936KGHcv755293xhlnrAS47777ZlNqQlptsOeee+6zcOHC5f0dd/Xq1V3Aln0cd97OO+980MKFC//VX9q1a9dCqTVqLeM5j3nMYw5duHDhYI++H9tH2hnbbrvtExcuXPiof7oWj6OUabPpW2655eELFy4c7BH0rjy6CUjX5ptvfsTChQuvHShh1QSkNW3YZJNNjli4cOEVjQV9lVMIYc+cc3frPjfaaKMnLVy48E+DHHevPtL2brDBBk9auHBh69/hEaZNm7bP2rVrW9OumT9//hELFy7s6TNRpaura7/e3t7Wc6ln3XXXPXzhwoUDPoLq6uo6oK+08+bNe+LChQvvHijt9OnT91+zZs2j0q6zzjqHLVy4cNFAabu7u/fv6elpTbtm7ty5hy5cuPChe1FfZdTd3b1fT0/Po/7Os2fPPnjhwoUDNjGYMWPGAatXr27938izZs06aOHChZcPlHbmzJkHrlq16lHtyGfNmnXgwoULLxwo7axZsw5aufJRTyG7Zs6cecDChQt/P1Da2bNnH7JixYrW69L0GTNm7DfY9W7OnDmHPvjgg7088lya0d3dPWjauXPnHrZ8+fI1PPIcnjF9+vRHpO2rjNZZZ50nPvDAAz088h43Y/r06fsPdtx58+YdsWzZstWtabu6ugbN83rrrXfEfffdtxpo/t+a0dXVtcfixYvXHShtazYa74sXL37UygULFtzfzk5CFUV2LISwEeXZ/0uBx/PwcB/nA1+ltCOYEuOPxRh/BTwZmJNSWtWy7gJg+5TS5qNx7MWLF78TOHUk9nXzzTdzyCGHjMSuJEmaNKZPn85RRx3F5z73uRHb54IFC0Jbxx7ugXLOd1N6RX4yhPAESuD2QuAwSoP1z1DaJkwFl1LaFe1HCVgBiDHOAvYEBvzmM0wfAD4+1ETz58/fo6ur67ze3t7D7r333qsBtttuO2bPnv3eFStWvLrabC3Qu8UWWxy/0047Ddog/sILL3zdypUrT+bhRyl58803f/HOO+88YE0GwJ/+9KdXrFix4rU8XP3Mpptu+pJdd931ysHSXnTRRS958MEH3wKs7erq6urt7V2z8cYbn/z4xz/+ksHSXnzxxccvX778FB6uOg8bbrjhq/bYY49BG6Zfeumlz1u2bNk7m9JO22CDDV675557njtY2ssuuyzef//9729K2zV//vw37bXXXr9ubHP88cfvfOihh551/vnnP++MM874a2P55ZdffuR999330SotwLT11lvvbXvvvfdPBzvulVdeuXDp0qWfak47b968d+y7774/HCztVVddddi//vWv06q0AZi2zjrrvGe//fY7c7C0f/7znw+4++67vwjkadOmTV+7dm2eO3fuB/fff/9vDZb22muv3fuuu+76avVrAKbNmTPnEwcccMBXBkv7l7/8ZY8777zz61W6AITZs2d//sADDxz0qnv99dfvsnjx4jMoNYMBCLNmzfrqQQcd9Inm7foqpxtuuGHH22+//TuUWoUuIM+cOfPbBx988AcHO+6NN9643a233nom5dt9F5BnzJjxg0MOOeRdg6W9+eabt7r55pu/T6nZ7wJyd3f3Tw8++OD/mjZt4MEBbr311s1vvPHGHwBzpk2b1r127do13d3dvz344IPfPFja22+/fZMbbrjhbEqbsi5g7fTp08876KCDXjdQbTPAHXfcseH111//g5zz/Ebarq6uiw8++OBXDpb2rrvuWu+66647O+e8YZW2t6ur68oDDzzw5TNmzHioA0BfZXT33XfPu+aaa87KOW/aSDtt2rTrDjjggBNnzZo1YAeApUuXzrnqqqu+n3PeointDfvtt9/xjRry/tx3332zr7zyyu+uXbt2m6a0N+2zzz4vWGeddVYNlHb58uUzLr300m+vXbv2McD07u7usHbt2lv22GOPY+fPnz9gBcmKFSu6L7744m+sXbt258ZxQwh37LHHHs/bYIMN+q2ZB1i5cuX0iy+++Ku9vb27N6Vdsttuuz1v4403vm+gtD09PdMuvPDCL/X29u7dlHbpzjvv/JzNNttsaWO7vspozZo14cILL/zcmjVrDqKch70hhPt33HHH52yxxRYD1tyuXbuWP/7xj59cs2bNEY20wAOPfexjn7fVVlvdOVjaCy644MM9PT1Pq9KuWbNmzYp//etfhwKDPRFoNo/SpnRLoO3ODq2GXcPW505Lr5kPUUb8zznnAavvJ4sY4+OBq4EftozD9lrKOGwvSCl9d7zy15eenp69KA1u9+7u7n7o8U7Vq+b5lMD7fuDLeWg9H59HaXewHPhqzvmvgyRpTvts4CmUR8yn55wHDfSa0h4za9asY0444YSTL7jggkOuvfbaofQEfDrlEX8PpQfSgI80WtI+hdJbs5fS0+viIaQ9gtI2ZC3w/dzSe7G/MqrSHkrpsQWlZ+tQelweSOkp1kXp2fq7IaTdl/LFrBv4Sc75V0NIu9fs2bNfdtxxx/3Hb3/72+fdfvvtPxhC2t0pnUtmAb/OOf94CGl3AV5G6SX6u5zzUI67E3AS5cJ7LqUX4SMungOcS48BTqb0Ej2f8v/R1oU3hLAdpSPO+pTG7d8cQtqtKB3DNqB0Ejs9t9/zcYu5c+e+/lnPetb/+/nPf/66pUuXnjaEtJsBrwY2pfQS/WJuv9fkxpROS41eov+b2+81uQFlHMxGL9HP5ZwfETQNUEbzq7SNXqKn5ZwHDJqa0q5bpd2GMhPQaTnntpq+VL1iX8vDvUQ/0+4TqapX7GtnzZq18+tf//qXhBAWfOADH2irN34IYRbwHzzcS/TTOef2HsuV+/urKR15bq/yvHTgVA+l7aa03Xs8sLhKe0/zNgOU0XTKubAnpR39Z3POd7V53C7g5ZReondR/jfa/VtNo1w39qV0vvt8HsLIBQDV49P7gPXaffzZZ15GMmALISygXExPpLRVCcCanHNr24JJK8b4GcoF54fAzyldn18HnAc8uW4zHQwUDExUI3Vy1IVlNDFMtnKyjCaGyVZOllH/hv1ItIq2n015FLqQhx8b/A34GqW30lTyBkqX+FdQamuWAJ+izCVaq2BNkiRNDB0HbCGE/YCXUB6brUcJ0pZRuqJ/Nec8YA+oySql1EuZQ/Rj450XSZI0OXQ608F1lC72jZ4N51F6hH6/3Wf3kiRJak+nNWw7Uxobfh34Wh7CFD6SJEkamk4DtiNzzr8efDNJkiQN18CD6vTvbSGEr49oTiRJktSnTgO2g+hgGiRJkiQNXacB2+0YsEmSJI2JTgO2nwKHVqM0S5IkaRR1GrC9izJq79khhG1GMD+SJElq0Wkv0Y9R5mo7GvhbCOFKyuj+fY3BlnPOJ3V4HEmSpCmv04DtJUBjmqUZwP7Vqy+ZMmmyJEmSOtBpwPbSEc2FJEmS+tVRwJZzdgw2SZKkMdJppwNJkiSNkU4fiT4khLALZSDdjYHrcs6pWj4NmJ5zXj3cY0iSJE1lHdewhRC2CiH8FrgG+ALwXuBZTZucDKwIISwcVg4lSZKmuI4CthDCBsAfgCdRhvf4PBBaNvsesBaIw8mgJEnSVNdpDdt/AtsCHwX2yDm/pnWDnPNSSu3bIR3nTpIkSR0HbM+kDJT7tpxzHmC7m4AFHR5DkiRJdB6wbQNckXNeO8h2q4ENOjyGJEmS6DxgWwnMa2O7rSlzjkqSJKlDnQZs1wN7hRDm9rdBCGEjYA/gzx0eQ5IkSXQesJ0FbAh8vBpvrS8fAeYAZ3Z4DEmSJNH5wLmnAScCLwf2DiGcXS3fIYTwJuBYYD/gKuD0YeZRkiRpSut0LtGVIYSnAd+nzHLwhGrVIdUrAJcCz8o594xERiVJkqaqjqemyjnfARxSBW5HAdtTHrH+A/gF8ONBhvyQJElSG4Y9l2jO+VfAr0YgL5IkSepDx3OJSpIkaWx0Opfo/BDC7iGE9VuWbxpC+FoI4coQwg9DCLuPTDYlSZKmrk5r2E4BrgS2aywIIXQDfwROoIy/9kzgnBCCU1NJkiQNQ6cB2xHArTnnK5qWHQvsAPwJeBbwFWB94NXDyaAkSdJU12nAthXw95ZlRwMZeFnOOeWcTwZupfQglSRJUoc6Ddg2AJa0LDsQuCnnfEPTsisowZ0kSZI61GnAtgqY3/glhLAZsA2lDVuzFcDsDo8hSZIkOg/YbgAODiHMqX5/DuVxaGvAtgC4q8NjSJIkic4DtjOB9YA/hBA+AXyQUuuWGhuEEKYDe/Hotm6SJEkagk5nOvgU8DTgScDeQC/whpxzc7u2pwDrAucPK4eSJElTXKeTv68OITyFMtH7psAVOeebWjZbCbyRplo3SZIkDd1wJn/PDFB7lnM+Bzin0/1LkiSpcC5RSZKkmuu4hk310tPTszmweQdJH9d47+npGcEcjZ/1119/7rJly5g3b94ePT09y8c7PyPAMpoYJlU5WUYTwyQspylXRt3d3Vf0la5VKE82NdH19PS8Ezh1vPMhSZLa193dHdrZzoBtkhhmDdsZwPHA9SOaqXGyZs2aucuWLTtv3rx5h02fPn2yfOO0jOpvUpWTZTQxTMJymnJl1G4Nm49EJ4nu7u47gDuGmq6pyvn6dv9p6m7JkiXrAixduvTqBQsW3D/e+Rkuy2himGzlZBlNDJOtnCyj/tnpQJIkqeYM2CRJkmrOgE2SJKnm2mrDFkLYejgHyTnfNpz0kiRJU1m7nQ5uATrtTpqHcBxJkiS1aDeQuo3OAzZJkiQNQ1sBW85521HOhyRJkvphpwNJkqSaM2CTJEmqOQM2SZKkmus4YAshdIcQ3hxCuCiEsDSE0NvPa81IZliSJGmq6Wi4jRDCTOB3wIHAYLPMtzULvSRJkvrWaQ3b64GDgF8DOwHfoAz7MRPYDfgQsAp4T87Zx66SJEnD0OmAtscCy4Dn55zvCyFkgJxzD/AX4JQQwoXAj0II1+SczxqZ7EqSJE09ndZ+7QhcnHO+r/o9A4QQuhob5Jx/AlwJvHZYOZQkSZriOg3YuoElTb+vqN7Xbdnub8DjOzyGJEmS6DxguxPYvOn3O6r3nVu2WwB0IUmSpI51GrD9FXhM0+8XUnqDvjWEMA0ghPBE4FBKLZskSZI61GnA9itgyxDCftXv51I6GxwDLAohXA78hhLEfW64mZQkSZrKOu0l+m3gHuA+gJzz2hDCs4AfUNqsbQr0Ap/OOZ8+/GxKkiRNXR0FbDnnu4EzWpb9H7BHCGEnYAPghpzzPcPPoiRJ0tTWaQ1bv3LOtlmTJEkaQR21YQsh3BRC+FAb230ghHBjJ8eQJElS0Wmng22BjdvYbqNqW0mSJHVotOf5nAWsGeVjSJIkTWqjFrBV01TtwyNnRJAkSdIQtd3pIITw+5ZFR/axrHm/jwU2oQwBIkmSpA4NpZfo4U0/Z2Cz6jWQy4BThpgnSZIkNRlKwHZE9R6A3wO/BPrrKboauD3n/I9h5E2SJEkMIWDLOf+h8XMI4Q/Auc3LJEmSNDo6nengiMG3kiRJ0kgY9kwHIYQZwN7AFtWiRcDlOefVw923JEmShhGwhRCmA6cCrwXmtaxeFkL4NPDunLPjsEmSJA1DRwFbCGEakICnUTohLAVurlZvB6wP/DewdwjhmJzz2hHIqyRJ0pTU6cC5LweOBG4Fnpdz3jDnvE/12hB4brXuSOCkkcmqJEnS1NTpI9ETgBXAk3LOt7SuzDn/MIRwFXAdcCLwpU4zOFwxxpnA24EXAZsDtwNfAT6SUhr0cW2MMVIC0AOArYB/AVcD70spXdiy7bY8XNPY6oKU0iEdfgxJkjSFdRqw7UYZ1uOW/jbIOd9czYQw3kHKmcAzga8CfwIOBN4P7ECpKRzMF4F7gbOB/6MMFvxK4IIY44kppW/0keaH1fbN7uok85IkSZ0GbDOB+9rYblm17biIMT6DEqx9PKX05mrxl2OM9wJvijF+MaV0ySC7eUFK6ZyW/X6JUnv4kRjjt1JKrW30/pxS+tYIfARJkqSO27D9AziwmuC9T9W6AyiPIMfLC6v3T7Ysb/z+osF20BqsVcvuAs6jzJW6SV/pYoyzYoxz2s2oJElSfzoN2H4FbA18KoTQ3bqyGpvt09U2v+g8e8O2L7AopfSIKbKq3xdX6zu1JdBD3zWNb6a08VseY7w1xviOGOOj/k6SJEntaCtgCyH8PoTw1qZFH6S063oVcFMI4SMhhFdXr48CNwL/Tmmg3998o2NhAWUg374s4uHBfockxvh0YD/gBymlFU2r1lLmWf0vIAInU/4W7wbOijGGTo4nSZKmtnbbsB0O3NL4Jee8KIRwJPB9Si3am1q2D8BtlCE/+guY2hZjnA+8oc3N16aU3l39PAdY1c92K6v1Q83LtsA3gH8Cb2xel1K6DVjYkuTLMcZvAy8AjgZ+MtRjSpKkqa3jmQ5yzpeGEHYEjqUEdM1TU50LfH8Ep6eaT5lVoR29lBotgAfpv9PDrGp922KMC4DfAt3A01JKd7aZ9H2UgO3pjFLAtnjx4pl00MFj/vz5c7u6uujt7Z27ZMmSdUcha+OhMfPGvMWLF49rRkaCZTQxTMJysowmhklVTlOxjBYsWHB/OzsZ1lyiVUB2RvUaNSmlWyi1dkO1mP4fe25BqQVsS4xxE+B3wKbAU1NKVwwhH7dU7xsNIc1QnUL7Qe1D7r333saP541kZmpiPDu8jBjLaGKYxOVkGU0Mk6KcpmgZtRXfDHvy95q7FDg+xrhVc8eDGONWlPZtrWOl9SnGuDGlbdrWwNNTSn8aYj4eW73/c4jphuIDwMeHmmj+/Pl7dHV1ndfb23vYvffee/Uo5Gs8zKOcGFtShpaZ0CyjiWESlpNlNDFMqnKyjPo32QO27wDHU9q/vblp+Ruq90fUDMYYHwf0pJRubFq2AeUx6PbA0SmlfqP+GOOGKaV7WpZ1Ae+pfh219msLFixYRf/t9frV09OzHGDatGnL262WrbumKudlk+EzWUYTw2QrJ8toYphs5WQZ9W8oAduJIYQTOzhGzjmPS2CYUvpZjPGnlEFy1+PhmQ5OAk5PKV3UkuSvlDlQt21a9htgd0pHgwUxxtax236TUmrUnH0pxjivOs4/KGO0HddIn1L69Yh9OEmSNGUMJZCaqENSHAu8gzJI7osp1ZJvBz7cZvq9qvcTqlerI3j4UefPqmO8AtiA0hP1GkqA+LUO8i5JkjSkgO2XjO+Yah1JKa0E/rt6Dbbto4LSvpYNkP4rlInlJUmSRsxQArY7c85/GLWcSJIkqU+dTk0lSZKkMWLAJkmSVHMGbJIkSTVnwCZJklRzbXU6yDkb2EmSJI0TAzFJkqSaM2CTJEmqOQM2SZKkmjNgkyRJqjkDNkmSpJozYJMkSao5AzZJkqSaM2CTJEmqOQM2SZKkmjNgkyRJqjkDNkmSpJozYJMkSao5AzZJkqSaM2CTJEmqOQM2SZKkmjNgkyRJqjkDNkmSpJozYJMkSao5AzZJkqSaM2CTJEmqOQM2SZKkmjNgkyRJqjkDNkmSpJozYJMkSao5AzZJkqSaM2CTJEmqOQM2SZKkmjNgkyRJqjkDNkmSpJozYJMkSao5AzZJkqSaM2CTJEmqOQM2SZKkmps+3hnQyOjp6dkc2LyDpI9rvPf09IxgjsbP+uuvP3fZsmXMmzdvj56enuXjnZ8RYBlNDJOqnCyjiWESltOUK6Pu7u4r2tlPyDmPfO405np6et4JnDre+ZAkSe3r7u4O7WxnwDZJDLOG7QzgeOD6Ec3UOFmzZs3cZcuWnTdv3rzDpk+fPlm+cVpG9TepyskymhgmYTlNuTJqt4bNR6KTRHd39x3AHUNN11TlfH27/zR1t2TJknUBli5devWCBQvuH+/8DJdlNDFMtnKyjCaGyVZOllH/7HQgSZJUcwZskiRJNWfAJkmSVHMGbJIkSTVnwCZJklRzBmySJEk1Z8AmSZJUcwZskiRJNWfAJkmSVHMGbJIkSTVnwCZJklRzBmySJEk1Z8AmSZJUcwZskiRJNWfAJkmSVHMGbJIkSTVnwCZJklRzBmySJEk1Z8AmSZJUcwZskiRJNWfAJkmSVHMGbJIkSTVnwCZJklRzBmySJEk1Z8AmSZJUcwZskiRJNWfAJkmSVHMGbJIkSTVnwCZJklRzBmySJEk1Z8AmSZJUcwZskiRJNWfAJkmSVHMGbJIkSTVnwCZJklRzBmySJEk1N328MzDaYowzgbcDLwI2B24HvgJ8JKW0po30LwG+1s/q96WU3t6y/TTg9cArge2Au4DvAqemlB7s8GNIkqQpbNIHbMCZwDOBrwJ/Ag4E3g/sALx8CPt5P/DXlmXX9LHdJ4DXAT8EPgbsDLwB2DPG+NSUUh5K5iVJkiZ1wBZjfAYlWPt4SunN1eIvxxjvBd4UY/xiSumSNnf3m5TSuYMcb1fgtcDZKaXnNi2/Gfg0cCzwvaF9CkmSNNVN9jZsL6zeP9myvPH7i4aysxjjvBhj9wCbvAAIfRzvS8CDQz2eJEkSTP6AbV9gUUrpH80Lq98XV+vblYD7gVUxxitijMf1c7y1wCNq7VJKK4Grhng8SZIkYPIHbAuARf2sWwRs0cY+HgS+TWmHFoE3AusBZ8YY39TH8e5OKa3q53ibxRi72jimJEnSQyZEG7YY43xKwNSOtSmld1c/zwH6Cp4AVlbrB5RS+h4t7c5ijF+m1Ji9L8b4zZTSkjaPBzAbeGCw4w7V4sWLZwIzh5pu/vz5c7u6uujt7Z27ZMmSdUc6X+NkXuN98eLF45qRkWAZTQyTsJwso4lhUpXTVCyjBQsW3N/OTiZEwAbMB05tc9teoBGwPUj/Qcysav2QpZSWxxg/CXwWOIKHA7oHgU0GOB7Aik6OOZgFCxasov9gcSDnU9rdMWfOoPHrRHE/1WeaJCyjiWGylZNlNDFMtnKyjPoxIQK2lNItdPZhF9P/Y88tgNs6zRNwS/W+UcvxdokxzuzjsegWwJ0ppd5hHFOSJE1Bk70N26XAFjHGrZoXVr8vAC4bxr4fW73/s+V404D9Wo43C9hzmMeTJElT1GQP2L5Tvb+hZXnj9zOaF8YYHxdj3KFl2YatO62WvRlYDpzTtOpMIPdxvJMp7dvOQJIkaYhCzpN74P0Y40+AoynTUTVmOjgJOD2l9NKWbTNwa0pp26Zli4DzKLMa3AVsT5khYSPg5JTSV1r28RngNZSZDn5OmengddU+nuxMB5IkaagmRBu2YToWeAdl0NoXU+YSfTvw4TbTfxc4HHgqsC6wFLgI+FhK6Q99bP8GSvu2VwBHAUuAT1HmEjVYkyRJQzbpa9gkSZImusnehk2SJGnCM2CTJEmqOQM2SZKkmjNgkyRJqjkDNkmSpJozYJMkSao5AzZJkqSaM2CTJEmqOQM2SZKkmjNgkyRJqjkDNkmSpJozYJMkSao5AzZJkqSaM2CTJEmqOQM2SZKkmjNgkyRJqjkDNkmSpJozYFNtxRjDeOdBkqQ6MGBTnc0FiDF2jXdGpIkqxjg9xrhu8xcgvwzVS4xx7xjj9uOdDw1svM8bAzbVUozxROCGGOPOKaVeg7b6Gu+LmPoXY3wKcDpwPfC7GOPLYoxdKaU8vjlTQ4zxZOACYKcYo/fkGooxbgCQUsrjeb3zn0O1E2PcBvgwsBnwkxjjLgZt9RNjXADjfxFT32KMLwK+B+wEXAM8FvgvYNPxzJceFmN8CfC/wJeAq1JKa8c3R2oVYzwO+GKM8UAY3+udAZvqaBXQC9wIzAZ+HmN8nEFbfVQXsR/EGJ8DBm11E2N8KvBJ4BvAi1JKTwNeAGwP7NayreU2Dqpg7auUcvpwSumOcc2QHiXGeCTwXeA5wJtijHvD+F3vQs7WjKs+YoyhOhk+T/lCcRPwPuB24MiU0vXVI53e5u3HMctTThUM/LL69SLgvSmln1frLI9xVj1W+xqlZu3ElNLfquUHAF8BjgdmAYuAO1NKPTHGadbujJ0Y4wuAMyhPEk5LKf2jWn4M8BjKF9UbU0pnjl8up7YY42Mp59GmwHnAicDPgXellC6vthnT6501bKqVpn/+e4CDKBe0/6acNL9qejw6N8Y40+BgbMUYdwDeBvwd+AiwD/DeGONRYE1bTcwBngjc0QjWKgcA2wHnAhcClwAfiTHOSSmttdzGRoxxC+D11a9XNAVr3wfOBj4GvBf4TozxrBjjLuOT06mr+tKzD+Ue9OWU0kmU694zgFNjjPvA2F/vDNhUK03//D8F1ge2Til9iFLLtgnl8ei+wBeBT/qIdMztDBwOnJFS+k9Kbc1uGLTVyYPADcABMcZdq9drgY9TanVeCyyk1Fq/DvhgjHGGX37GRkppEfBR4Ergc1UP0e8BRwBvoZxjBwCfogQIH4wxzgEfX4+Vqrb578DrqvsPlHvOKZQy+Z+WoG1M7kMGbKqVppvG3yjDejSCgPcC76LUtJ0LROCHQPfY53JKuxx4aUrp3QAppe8DLwZ25dFB2yMuYt5sxkZ1s/kR5bHaNcBvKDf/LwGnpJS+mVI6h1J7cBXwXGDBuGR2imn0Ak0pnQW8E7gTuBQ4BHgR8PmU0t9SSpcAH6DUth0NnFylM6geIymlyyhBWuPR5/3A5+g7aGs00Zk/mtc5AzbVRuMGH2OcnlJaClwM7Ni0ySeBm4GZwEpgSUpppbVsY6dqGH0GPByAVe1s+graGhexzRxKYmw0lcnngJdQbvpnAdcCP0sp3V1tNyel1AN8Aticlo4IGh3N7QRTSj+hNPf4HaU37wUppdVNZXhXtXwNsLdfeMZW1a5zNTwcKKeUlvPIoO3UGOMe1fZPpjzKPnS08mSnA42LqrfN9sDWwF8pF6v7WrZ5H/BCyiOCGZTxpI4Afg08vdps35Z2OhonMcZ/A74JXAe8LaX0qxjjEcBJwM9TSt8e1wxOQjHGdVJKD7Qse0QHghjjXODrwKdSSufHGGellFZW694FvBnYL6X0l7HM+1QRY9wO2BjYBbga+Gvj71+tPxq4JqV0a9Oyh8owxngP8MuU0vFjm/Opo537Ucv2c4HXUJrq/Lx6vRzYC9ghpXTzaOTTGjaNuRjjiym9DL9Mabj+U+CyGOORMcZ5TZteRqlN24Zyw3kS5eb/IkrNwHLAnm2jJMa4zlC2r2raTqTUtH0gxngKpdPIcZQG7hpBjfMoxrhT8/I+entOp9SgvS/GuEFTsLYX8GTgz8A/xyDLU06M8bnA94HzKUN4/A74UHXDByCl9NOU0q2NGrTq8VsjWHsOpdnHH8c881PEEO5HD6lq2j5B6YjwFOA0SsC352gFa2DApjFWVRv/L2V8qKdTOhacAqymVP+/Osa4ebX5uZSbzSWUmrVXAb9OKfWklE4FHp9S+vvYfoKpob9gYJA001JK36EE1DtRvn3uAOyTUvq/0cnp1FQNrXI6pR3aF2OMj+lv26qm4A+UdlI/jDEeE2P8b8rNaWfg5JTSPaOf66mlqnE+g9IB5A2UsbwWUTp9vLja5qHHnFW7z2mNx29V+6hXUdq5/XRMMz9FtHk/2qwlTeOR9WpKbdyDwL3AoSmlP49mfn0kqjEVY/wwcCxwVOMRTNUQd2/gHcCRlHYA/wssozS63Rv4NHB2SmlF8zhsGnlVMPALIFBqBk4aSsAVYzyEMtjkbMpFzEdtIyiWOSdPpzy++RXwfOAvwItby6l5nKgY4894uCnBGkpj95Mtn5EXY9yP0jzg98AHG487q5v/n4E/pZSe2U/a6ZRa6VdSakaPGO1AYKoawv3otNYvNdV18iPAVsBhKaVrRzu/1rBpzFSdA3YHVjSdHN0ppbUppUspQwz8lFLNfHRKaQXwIeDfgR9Vv2OwNnqqYODtwD8ovQr3BL45UA1OS/qnAZ+nGgvMYGBkVTeT/YADgc9Qzo13UW7sjyqnqtZmevXzUZQehy+lNIx+puUz8mKMMyi1ad3AN5qCtRnA3ZSmHvvGGDeNLXOHVr9/FPgWZXDjUa+1maqGeD+K1frm8toGeDwloB71YA2sYdMYizF+FngF8OSU0nnVsuZagJ2BL1Aa6O6TUrqltRG1Rkd1MTqOUjPwNsq4XW+kBATX0kcNTh/7aLTZeUJK6erRzfHUVDWQPjyl9LHq9w0pQdj/UDp8PFROjXPHWumxUwXIHwfWTSm9pI/176UEA4+peoK2rl+PUuvzi2rMNo2SIdyPdqbcj25tWb9JX2U4Wqxh01g7h9Iu7YUxxk3gUQOtXk95/DkP+M/mBrgaXU2DRb4tpfSx6qL0dUrAtistNTittQPVPn4AbGSwNnpSmRbn01BqCapHNV8G3k1LOTWdO7PHI69TUUppDaUpx5uhz/EHH6DUQD/iutY0Rtt9KaUvG6yNiXbvR+tSvsQ+wlgGa2DApjFW3dBPp4wRdVyMcXa1/KEGt6kMKnk5pVOBVcBjqJNgoNGbtGk8vKVjne+pphpDjVSmaQsppXt5ZDl9K8a4LTw0gfW3Y4x7jk9up56U0q2NNk9NtTGN++09lPahD/VAjGX6qXfHGOePcVantKHejxrrxim7BmwaF5+nNHj+EPDiGOO68KjhCO4EZsYYnclgjHUaDDQeuRlkj61GjUBTOb2H0qTgO1Vv33dS2q6t7HcnGguN86KXErCthoceu30IeCuw4fhkbUqbMPcjAzaNuapB5/so0+Z8EnhzbJrgOMa4G/CYar2PQ8eRwcDE0FJOn6M8xt6Z8kh7Z2CPlNL145jFKa/pi0zjpr+mqq3+MGXYon1TSjeOS+amsIl0PzJg04jro83Go9allH4J/D9Kt/d3AGfGGN8eY3w3ZRDCLYAP21B6/BkMjI+BzqO+tk2PnD7n75ShO5YCB6aUrhmdXE5tQyyjRpOBFdV7Y4L3I4CDbfc5OibT/ciATSOm6q3W1iOxGOPclNL5wPGURwHzKI/cXkX5v3yiQcDoMRior3bOo/jwqPjrt24bY3wi8H6gC4dWGRUdllHjZr+qen8XcDhwiMHayGvuRNDGthPifmTAphERYzwB+FSMccsBtglVbc0BwFkxxv2rHlEfBfYFHksZ9+sZYzWuzVRjMFBvHZxH36reG+u6gS2BucCTPI9G3nDLiHLuAGwHHJBSumr0cjs1xRifSZnV4zUDbDPh7kcGbBq2GOOJlJ42iymzE/S1TePk2JcyeXsvcHNTlfSSlNKNKaVFKaU+96HhMRiotw7Poww81O6p6jDya0p7qCtHPdNTzEiUEaWB+1cpwZq10yOsalv7LUoZPdDPNhPyfuTAuRqWGONLga9QBor8VErpH31s0zg59qdMdfRj4E19bavRUd1ovkYZRf19qcwv2bpN80Xsd8B5wEtTSkuattkYyCmlu8co61OC51H9jWQZxRhnp2rmFo2cGOPhwFmUgO2zaYCBvifieTR9vDOgiauqsXnUBayqwVkHmJZS+kvTI7XdKHMfvnkinByTRcuN5jODBGutF7Elzdu1/q7h8zyqv5EuI4O1UfNESm3mV9PDs32cQHkyMB34E/CHVCZu350Jdh5Zw6aOxBgPBC4AzqVMIH1jtfxTwFOB7atNz6SMc3NxKlPkrJNS6rOaWiOvulidziA3mqbtTwKeBfxHSum2Mc/wFON5VH+W0cQQy5Rg5wOLUkrPq5YlygTujcqpHuDblOvbgzHGdVNK949LhjtgDZs6FShdoPelNMy8Mcb4C8qk0udSqqX3p9z8d6VM03IusHzMczpFVTea0yl/9883BWuPuNHEGJtvNF+JMZ7pjWbMeB7Vn2U0cdxHmUmCGON3gQOBk4C/UeKd04ATgRkxxpdNpGAN7HSgDqWULqTMrXYZ8NUY48WUMbmOBV6YUnoH8EJKt+jtgNdX6azSHTuNG83elBsN1Y3mJMpjgw8Df6DcaD4LHFal80YzRjyP6s8ymhhSmcP1euC5scwesQHwXuC7KaVLqnJ8InAR8ALg2TC0IY7GmwGbhqypJ81llAvZHynzrH0I+G3jW0vVMP2nwNnAM2OMh4xPjqcmbzT15nlUf5bRxFA9DgX4BaXH51eAJwN3Vj2niTFOr8rrpZTeowfCxLreGbCpLTHG9WKMC2KMG1BqboCHpvX4IPAx4BeNk6NKM61q4P7ratHcsczzVOaNpp48j+rPMqq/5jKq/vZrqlW/Bn5DmUXiQWB+tX0XJZAD+BdlKr3NxjbXw2fApkHFGJ9HualfB1wL/D7GeGiMcT2AVEaI/khK6Zb48KCrIT08ee6elG80t4x13qcSbzT15nlUf5ZR/Q1QRutXtWUnUtoQzgH+O8a4U0qpt6kmbVdK8HZVtT8fiWpyiDEeB5xBacj5EeCXwLaUque3xhh3AEgp3d80NMS0xskRY3wC8CTgYuDOcfgIU4I3mnrzPKo/y6j+BimjtzSCM8rj0J9QhvP4XYzxhTHG3WKMEfhvymDG34WJ9UjUYT3UrxjjppSal78Ab0kpLaqWPwH4T+A4Si/ED6SU/l6tC00XsKdRekztQ5nc+K9j/iGmgOoi9k3KResS4DGUG8dGlMmlv9o0FEHzjWZttewJlF6iy4Dn9TVOmzrneVR/llH9DaGMPppS+kv1xfR9lDa7O1DmP76vej0npfTnMf8Qw2TApn7FGLel9Lr5r5TSx2OMXdW3F2KMcymj5r+S0sPw/SmlO5vWfZnSwH0d4NnJKVhGhTea+vM8qj/LqP6GWEYfaRrGaHvgYEpt203AHxvXyYnGR6IazAxgHkBKqbepMftySq/Cr1NOkqdBaRNFaew5C/gz8DQvYKNqNrATcGlKaVHVuJZU5pE8CfgC8BLgtTHGzap1OcY4N8b4HUonhO0pE7kbrI0ez6P6s4zqr90yelIjQUrpppTSN1NKH0gpnTlRgzWwhk39qE6EDSmNN+dRHpVd2ljXVEOzNaVNwdbA7s2P02KMc6sTSaOk+tZ5E/CulNK7qmXN5TODErS9EHhFSunr1Y0mU3qGLqvS3tjX/jU8nkf1ZxnV33DKqHn9RGcNm/qUUmpM8P1pYCvg5THGrRrrmnrWLKJM9bEV1beaKiDAC9joqsrgAcrj0JfFMmn7I8onlTnzTqW0bXt3jHG9lNLaqnyfDbzKYG30eB7Vn2VUf8Mpo8kSrIEBm/rRdAJ8Gfga5fHaK2KMC+Chk6S7akPw3Wrbxrq1rfvTyPNGU3+eR/VnGdXfcMpoMjFgU58a30qqC9JHgJ9RGrG/KZZpP0gPj+d1EKXnza3jkNUpyxtN/Xke1Z9lVH+WUWEbNrUlxrg7ZfyaY4HzKMNA/JRycrwG2B04ZCI36JzIYoyPo3QgeDqlxu0rzZ0IYoxHAd8CXpxS+un45FKeR/VnGdXfVC0jAzYNqGW8rvUoQ0CcAnQBq4EVlIbrR0/EcW0mk6l6EZsIPI/qzzKqv6leRgZsU9hgvWeaBlndA9gnpfSVavlBwI6UsYf+ApybUpp01c8TxVS/iI03z6P6s4zqzzIanAHbFBRj3DyldEf1c58nSdPJsT/wW8r4NqeklJaNcXanNC9i9eV5VH+WUf1ZRu0zYJtiYpnG6PXAh1NKP66W9XeSHAj8kDI33mtSNXK0Rp8XsXrzPKo/y6j+LKOhMWCbQmKMT6VMlgtwAfC+lNIvq3WPOElijPOBxcD5wMts9zR2vIjVm+dR/VlG9WcZDZ0B2xQRY9wB+BKwBfAT4A3AlcA7BjhJ9gcWGwSMHS9i9eZ5VH+WUf1ZRp0xYJsiYozPpNTEnJpSek+M8YXAN+jjJIHJNTr0ROFFrP48j+rPMqo/y6gzDpw7dVwGvDyl9B6AlNK3KZOCPwF4T4zxyGp5puX/ommAVo2u3YDDgW+llN4CnEAf5RNjDE0XsosN1saU51H9WUb1Zxl1wIBtiqgel30DHvGt5Vv0fZL0VtttWg0Z4bebseFFrOY8j+rPMqo/y6gzBmxTRPWPvgYeWb3ccpK8N8b45Gr7J1GmADl27HM7NXkRqz/Po/qzjOrPMuqMbdgmoRjjjpQ5I3cDbgDOTymtiDF2NW70faQ5AfgqpQ3B94HjKCPj75JS+r+xyfnUFpsGwO1j3YuA04GrgLellH5bXcReAvwspXTmWOVzqvA8qj/LqP4so5FjwDbJxBiPBf6HMmBqowb1bODElNLyvoaHaAQKMcbjKROJzwTuBQ5Pjow/KryI1ZvnUf1ZRvVnGY0sH4lOItX4Xd+itIU6EdifMuTDc4C39fforKlW51bgX8BSypyTU/rkGC3VRewHlMFuP00ZxuObMca5KaXevtqjVWX3DUq57gZ8ENieMruBwdoI8jyqP8uo/iyjkWcN2yQRY9wL+CbwR8rYXbdVy2dTpia6PaV06ADpjwQ+DGwJHJZSunb0cz31VBexbwLfpgRsNwAfBQ4F3kfp5t7nY9Eq/SHAmcAs4NCU0l9GPdNTiOdR/VlG9WcZjQ5r2CaBGON0IALrUYaEaJwcs1JKK4BfA/vGGLePMfZX5vMpNTdHeHKMjuoidiqlLdqpKaUzUkqXAkdSvk0ePkiwdiTwOWA28ESDtZHleVR/llH9WUajx4BtEmj0tgEuTimd37R8ZfXjdcAMYE1/AUFK6bvAximlq0c1s1OUF7H68zyqP8uo/iyj0WPANnl8GHgl9DkmV2My8Ecsb2wXY5xZLfrXaGZwKvMiNmF4HtWfZVR/ltEoMGCbJFJKD1L9g/fRkPOe6n29xoIY4+OB02KM66WUVvWTTiPLi1jNeR7Vn2VUf5bR6Jg+3hnQ0FUNz/ehPB67CLg2pXTRAO2fGv/4q6v0OwPvBY4BPgXcN7o5FpSLWIxxZfVzuxexV8UYT0kp3ddPOnXI86j+LKP6s4zGjgHbBBNjfDFlKIgVlH/8lwErY4zvBj6TUlreR7JG7UxPLBOMfwR4IvCElNLfxiDbU44XsXrzPKo/y6j+LKOx5SPRCSTGeDBwGvAV4BkppS2A51HGtnk/8KkY47ZN2zcerz1YvR9MufkfThnXxrZQo6C6iP0EeCvwdOCLwO9jjG+LMc7tJ1lfF7En4UVsxHke1Z9lVH+W0dgzYJtY9gdWAd9MKV0FkFI6G3gd8AnKNEXvjjFu0pKu0bD9FOAIPDlGjRexCcHzqP4so/qzjMaYAdvEsg1lDK4/A8QYuwGqGpiPUWplXgS8pVreeMw2q3rfAti/cXJpVHgRqz/Po/qzjOrPMhpjBmwTyz+BOcALq2k9eho1NCmlxcAXKFOBvCXG+NymdH+kjKZ/gON3jTovYvXneVR/llH9WUZjzIBtYvk2pav0i4FNoNzwm06SWygnyRLgxTHG6bFMrns/8F/JkfHHghex+vM8qj/LqP4sozHmXKI1VT0ymw88FrgQuC+ltDbG+Hbg3ZSG7K9pDMhaBQdrq59PA/4N2L46OTRGqvZpl1Wvl6SU7qyWh0ZtWtXO7WzgT5T2bb3VhW56eniAXY0Az6P6s4zqzzKqB2vYaijG+CzgB5ThIH5CubEfW31z+Q5l8u9XAJ+MMa4D0DJcRADupRoiQqMjxrhJjHHHGONRMcb1q4vULcAngacC74xlSqrGN89p1c8XAGcBhwBzGoGcwdrI8jyqP8uo/iyj+jBgq5kY4wuAbwAPUEbG/yRlyqKPAXuklG6slv8IeDXw5RjjAU3pdwX2AKxuHkVexOrN86j+LKP6s4zqxUeiNVI9KvsO8GPgEymlm6oamucA36VMGn5Cte3OwKuAkygn0wWU0fL3Araj9DL0JBkF1UXsC5S/+R8o7TeeRbmQHZ1SuirG+ATgHdXy7wGfTCldVKXflfII4R7guPTwfKIaAZ5H9WcZ1Z9lVD8GbDURY5wNfBB4MnBCSunypnXrAJcDdwKHN7WF2pByQvwP5aRYSZlE/BRPjtHhRazePI/qzzKqP8uonnwkWh8B2AVILSfH9JTSA8DfgE2BeU29cO5JKf2GMm7XEyhjgD3fk2N0VBex4ygTtZ+eUroJHmp79nPg78A2TeXzV+BdlFq2G4D9KGV1OwZro8XzqP4so/qzjGrIuURrIpWJwU8GGj1rpqWU1jY1RL8b2B14qLdhtd2MlNJqStdpja4BL2Ixxr8BO1IuYstSSjmldA/wmxjjOcD6lPJ9MKW0Yjw+wGTneVR/llH9WUb1ZA1bjaSUbkkp3Vb93DhRuqrVPZTJdR8qsxjjYykN3Tcb67xORSmlB4GTgc9DuYhVy5svYrPo+yK2JqW0pPoWarA2ijyP6s8yqj/LqH4M2CaOHqAL6IWH2kd9njIGjg0Rx4gXsQnP86j+LKP6s4zGgY9Eay6l1Fv92Et5JNcdY9yR0pV6P0qjz3+OV/70CH1dxD5DaYD723HM15TneVR/llH9WUbjyxq2mms06OThYGBXynyUhwOHppSuGKesqdLGRexYL2Ljy/Oo/iyj+rOMxpcBW/2Fpp/nUgYufDLl5Lh6XHKkR/AiNiF4HtWfZVR/ltE48pFozaWHR8f/FzAP2B44MKX05/HLlVoEHm630biI7QQc7EWsHjyP6s8yqj/LaHxZwzZx/Ai4EjjAk6NeBriIXTVumVJ/foTnUd39CMuo7n6EZTTmnOlgAokxzkwprRrvfKhvMcZdgG8Cx6eUrh/v/Khvnkf1ZxnVn2U09gzYpBHkRUySNBoM2CRJkmrONmySJEk1Z8AmSZJUcwZskiRJNWfAJkmSVHMGbJIkSTVnwCZJklRzBmySJEk1Z8AmSZJUcwZskiRJNWfAJmlchBAeG0L4bAjhLyGE5SGElSGE20MIl1bLnzveeRxMCOHcEEIOIRw+3nkZqhDCO6u8v3O88yJpcAZsksZcCOE5wDXAfwCbABcAPwD+DGxRLf/CuGVQQzaRg1dpIpg+3hmQNLWEEDYFvg7MBD4GvD3nvLJlm72B541D9obqBGAOcNt4Z0TS5GbAJmmsHQ2sAyzOOb+lrw1yzpcDl49prjqQczZQkzQmfCQqaaxtWr0v6SRxCGF6COHl1SO4f4UQVoUQbg4hfD6EsFUf2x9ePao7N4QwJ4Tw7hDCX0MID4YQbgkhPK5avzSEMGuA415WbffMpmUDPgYMITwphPD9qm3eqhDCkqqN3rtCCBv2sf2OIYQvhBBurNr03RdCOC+E8KIO/1azq7Zqf6+Of0cI4eshhK0HSDMvhHByCOHsKt3y6nVNCOF9IYT5LdsfHkLIwBOrRedUf5PG6yUt269fff6rQgjLqnK4JoTw9hDCnE4+pzQVWMMmaaw1aqV2CyEszDn/rt2EIYR5QAIOBx6g1MItAR4P/DtwbAjhKTnnK/tIPgs4F9gFOA+4Gtgw53x9COFPwIHAs4Dv9nHcxwN7A/8EftZmXj8NvLb69SrgfGA9YCfgf4Bzqvw0tj8W+EaVz+uBn1fb7w98M4TwpJzzy9o5drW/OcDvgAOA5cCvgRXA04CjBvgcewBfpPxd/0b5G69P+fz/BRwXQjgg53xPtf2dlEfcR1KC8V9Vyxr+rylPuwC/BLYC7gD+CPQA+wHvAZ4bQjg853xfu59TmjJyzr58+fI1Zi/K49DbgQyspQQubweeAWw8SNozqnQ/ATZpWfeGat0NQFfT8sOr5ZkSpG3Wx35fXq3/ZT/H/Xi1/qMty8+tlh/esvy11fK7gSP62N9+wFZNvz8eWEkJqJ7Tsu02lM4YGThhCH/nj1Rp/gosaFo+B/hR09/knS3ptgQWAtNals+hBGYZOK2P4/X5t2haP5sSvGVKcDajZd/frtZ9dbz/R335quNr3DPgy5evqfei1DJd1BQ0NL+upNSWdbWk2bkK8BYB8/rZ78+qfRzdtKw5YDu0n3TzKLVQvcAWLeu6gbuq9Lu2rHtUkEJ5ctHY/jlt/j2+W23/5n7W71utv6zN/c0G7q/SHNnH+s2q4PBRAdsg+51DqRG7q491gwVs/16t/0k/69eh1GD2AOuP9/+oL191e9mGTdKYyzn/Led8AOVx37spj9Eabdr2BD4P/DKEMKMp2TOAAPwi57ysn12fW70f1Me6u3LO5/eTn2XAWZR2vSe0rD4K2Bi4JOd83QAfq2Hvavu7gR8OtnEIYRrw9OrXM/vZ7DLKI+AnDNTOrslelCD07pzzL1tX5pzvpDwiHShfB4UQ/jOEcFoI4WshhNOBzwGrgY1DCOu3kY9mR1XvfX7GnPMDlM85nRKgSmpiGzZJ4ybnfAlwCUAIIQBPAP4f8HzgycDrKY/2ALav3k8KIZw0yK437mPZLYOk+SolWHsJ8IGm5S+t3r82SPqGbar3v+WccxvbbwisW/38j/JnGHT7RYNss2X1fssA29zc18IQwiaUMfEOGeQY6wJLB9mmWaP8vhlC+OYg2/ZVftKUZsAmqRaq4OYK4AVVg/lI6QTQCNgaTwSuorRFG8jFfSxbMUia84AbgR1DCAflnC+sgpdnUNqXPaozwghpftLx9Ta2XzVK+Wj4MiVY+xNwKuVvvTTn3AMQQlgMbE6p7RyKxuf8JeXR50BuHeK+pUnPgE1SHf2aErBt1LTsH9X7BTnn14z0AXPOuXrs9x5KrdqFwIso18nv5ZzvbXNXjV6wO4YQQhu1bHdTgsnZwFtyzncPNe99aNTAbTvANo9aF0KYSwlQ1wLPaP3M1frNOszTP4DHAV/JOZ/V4T6kKcs2bJLGVGjjmR/QGCfs9qZlv6jeY5vtuDpxOiVYOa6q5Rvq41Ao7bDupjzWe9ZgG+ece4HfVL8eN4TjDORySpu3jUIIT21dWc028ajllGFEuoD7+wlQX0T/NWurq/f+KgIa5TdSn1GaUgzYJI21V1eDtz6qY0AongM0atAeegyZy9hqP6CM4XV2CGHbPtLPDSEcXwUkQ5Zzvp0SPK0LvB/YjVJj9vsh7GMN8L7q1y+GEA7rI5/7hhC2bFr0LkrA85EQwolVR4TWNLtVf5t28rCCMpYawCdCCJs37Wc2pVPH7D6S/pPSLm1+COHFLcc/gEe27WvVCK537Wf9FymPOo8NIXyoGlPvEUIIm4UQTh7gGNKUFdprEytJIyOE8AbgE9WvSyjDeNwNzKcMarttte5bwIk557VNaedRel4upAQ4V1Maz4cq3R7ADGDnnPP1VZrDKWO9/SHnfHgb+fs3Htle7d0551P72fZcygj/R+Scz21aHig9Kv+9WnQlZRDadSmPBbfvI82xlBq+OZTg5y+Uv88GlHHatgTOzDk/f7DPUO1vLiXQ3I9S23YOpS3eoZShSn5G6WTxrpzzO5vSvYGHy+di4CZKjedBlDI5jNKxYruc8y1N6Y4Cfkopl1/z8NAmX805X1hts2u1zbbAvZTx5W6vPvOOlKFb7so5d/rYVZq0bMMmaax9hRJkLaQM67ELZYT8NcBi4DvAN/oZjmJZ9Yjv3yiP5/amDANyP2Xk/DMoMyHcOIz8/Qj4FyVQypQgakiqdmuvCiH8mBK0HUCprbuX8tm/TglWmtN8P4RwKfA64CnAwZTHk/+kDDj7WcrQI+3mYXkI4QjgbcALKTMcLAV+Sxmo+CX9pPtkCOFm4K2UstmVMvPCfwD/Sz+9S3POP6tqx14FPIkShEGZzeDCapvrQgi7V3+TZwO7U2aYuJsSuH2UNoZCkaYia9gkSZJqzjZskiRJNWfAJkmSVHMGbJIkSTVnwCZJklRzBmySJEk1Z8AmSZJUcwZskiRJNWfAJkmSVHMGbJIkSTVnwCZJklRzBmySJEk1Z8AmSZJUcwZskiRJNff/ASYgV1QuztBXAAAAAElFTkSuQmCC"
+     },
+     "metadata": {
+      "needs_background": "light"
+     }
+    }
+   ],
    "metadata": {}
   },
   {
@@ -595,7 +671,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "source": [
     "from siuba.dply.forcats import fct_rev\n",
     "\n",
@@ -624,7 +700,20 @@
     "\n",
     "p.draw();"
    ],
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ],
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkQAAAJKCAYAAADN6loqAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8/fFQqAAAACXBIWXMAAA9hAAAPYQGoP6dpAAA/5klEQVR4nO3dZ5hkVbm38fuBGUBhgFFBGUkKoiAYEcxiPKKeLWYxEkTRV4+I4YiigBmPglnhIAIqghhwo4AIyAExEURBkSRDasIAM8OQB1jvh7Vaiprumeqa7q7uWffvuurqrp3qqV3pX2utvStSSkiSJNVspUEXIEmSNGgGIkmSVD0DkSRJqp6BSJIkVc9AJEmSqmcgkiRJ1TMQSZKk6hmIJElS9QxEkiSpegYiTXkRMTciTht0HYMSEadFxNxB1yFNNRGxXUSkiNhp0LVo+jMQVaDjTWPvrump63JrRFwZESdExJ4R8bAJrGmdiPhURJwdEQsi4u6IuDYijouIt0bEjIm67RVZCY/dj+uNZT9/ICJWW45trx0R+0bEduNX8fTQsV9vjYhZoyzzqY59/pbJrnGEep4bEadGxKJyOTUinjPCcmtExCcj4tiIuKLUf+kgap5IEbFTx+Oz3yjLzCqP8cD3QURsHxG/iIjLS023RMT5EbFPRKw9wvIvjohvR8QfI+L2qfI8nE780NHfgS+U/1cD1gOeC3wJ2DsidkkpHTueNxgRLwCOAdYEfg78AFgIzAFeAhwBbAn893jebkWuBz5U/l8JeDjwRuAA4DnAq/vc7trAPuX/0/ovb9q6E1gdeANwSOeMiFgJ2Lks03foHC8R8R/AL4FrgP2Au4B3AqdGxPYppZM7Fn9YWeYG4C/AQya53Ml2J7BTROyXUrqva96O5Mf4zskvawlblr/fA64FZgLbAHsDb4yIrVNKt3Us/+Zy+QdwfllWY2Ag0nUppR90T4yIpwHHAT+OiGenlP48HjcWEY8FfgHcCjwtpXRe1yKfjYhnAE8Zj9ur1K3dj2lEfB34F/CqiJidUpo/mNKmtWuAm4Bd6QpEwEuB9YEfkj+UBiYiVga+Qw5Bz00pXVmmH0H+AvTtiHhsRxi4FtgwpXRVWW7u5Fc9qX4GvAl4MfDrrnnvAM4kP5YDlVL6H+B/uiZ/KyL+AewPvIb85XHYx4HdU0p3li5EA9EY2WWmEaWUziJ/450JfLpzXkS8tDS/3xARd0bE1aWbbYnm+BF8ClgD2G2EMDR8239IKX2ze3pEbFaakBeWJuTjI2LTrmVWioiPlXE315auuGsi4vCI2HCEbaaIOCwitin36dbShXdURKw7wvLrRcT3I+KmiLgtIs4oXROHRUQaYflNyryhUsvVEfGtGKE7MiI2jYifl/u3KCJOiognLnVv9iildCdwM5CAu7tud1ZEfDYiLoqIuyLi5tJ98oSOZXYCLi9X9+noephb5p8UEfMiIjrW2aYsc3tErNoxfbMy/ZNddTy/PI/mlzoujIj/Lh/wdC3b036N3MWXym1+KnKX0PC2+wkuhwBPj4gtuqa/o+yfU0aotefnZERcUOaNdJ+fUu7Ll5ZR43OAjYFjhsMQQEppYal/U+CZHdPvGg5DyyMiXhIRP4qIyyLijshdPKdHxH+OsOxh5b6sGRFfL/vlrog4N3Lr1kjb/6+O5+jlEfEJ+vtS/2vgKnKw7dz+VsDTWDLsDs/fJiIOLTXcVi5nRcTOXcu9tty394yynTby+2a/QxLmlr9rd05MKV1TXufqky1EGlVK6YSIuAp4fkSsnlK6LSKeS26K/wf528tNwCPIb7BPBs4YbXvlQ7EBrk4p/XKM5TwSOB1oyV1pjwHeB/wiIrbq+La7Spn/M+BX5K64JwC7AC+MiCeklG7u2vYTgRPI37aOBp5K/oBbm/zNf7j+tcr9ezRwKHAO8LhyO5eNcH+fRO5aur0sf0Wp+92llm3KhxQRsQHw+3Kb3wEuBJ5e1r9pLDsKWKnjzTaAdYG3AY8HDu1sZo+INYHfkT8kDwf+CswGdgP+EBHPSSmdS973HwAOJHdz/qxs4tby9xTyN+4nkbtdAF4E3Ac8iPz8+G3HdIB/d9tExC7kD6K/kLtwFwDPAj5Pfl69sWPZJ9Hjfu1wODkMfq3U9B7gBxFxWUrpjyPvxhEdVfbBrsAHSz0PB15BDvtLhGLG9pw8qNT4cvJzvdNu5e/By6hx2/L39yPMG562DflxH087kbtnfwBcDawDvB1oI+KNKaWjR1jn1+TH+vPAg4E9yvKP6QxzEfEF8j48B/gYsCr5MXhlH3XeR+6G+mhEPDSlNPz62g24BfgxsO8I672K3I31E/Jzbi3g9cChEbFOSumLZblfANeR30O+1bmBiHgk8DLgxymlG3spNiLWIHfDrkFuOd8fWAyc1Mv6GoOUkpcV/AJsR36j3rtregJOXsa6bVluy3L9gHL94X3UsWVZtx3jenPLejt2Tf9omf6SjmkBPHiEbbyoLPvhEfbBfcAzu6Z/p8zbrGPaZ8u093Qt+6oyPXVN/wu5m+ohXdO3Ae4B9umYdkTZxg6j3Me5Y9xX3Zd7yR860bX8geQWo227pq9N/hb9245pG5dt7TvC7T61e/8Cp5IDwDzgsx3Tf0b+4JlRrj8CuIMctLrr+2DZ7vP63K/7lvWPB1bqmL5Bud9HjmG/Xlr+P5Q83mZmuf6Rcrvrk0NBAt7Sz3OS/CF7G3Bc17IPJgep03qo9etlu9uPMG+LMu+AXu7rGF+nq48w7cHAxcDfu6YfVuo4qGv608v0z3VM27Q8f/8ErNox/SHAUFl+px7q+/djU57L9wF7lHmrkr94HDTaPhjl/q1E/rKwYPj5UKYPv1c8tWv5vcv07cawX4f31fDlAuClvd7XsT6ONV/sMtOy3FL+rlX+Lih/XxcRM8e4reFt3LLUpUY2lFL6Ude035S/mw1PSNnt8O+uirVLa8l55A+UbVnSH1JK3d+ml9g2OfjMB/63c8GU0s+BizqnRcSW5NaSoygtNsMX8of5pcB/DNcJ7AD8Iy05gP0r3N8K06shcmvN8OXNwJHkb9gHdNQY5A+HPwCXddU4g/wN9DkR8aAebvMv5C65F5ZtD7cK/YYcjIanr0QO6KenlO4p676W/A34EOChXXUMtyQO76ue92uXA1PHANqUu4gu4oGPb68OIbd+NOX6rsCvU0pXj7TwWJ6TKbdsHQVsX1oThr2BfBDCslqHIIcQyGOIut3Ztcy4SQ9seVw9Ih5abudUYIsY+ei8B3T/pdxadytLvu5WAr6UUrqrY9mbgSW61nusdS65hXK42+w15IA1YndZWafz/j2o3L+HACeS39se27H4weTAtVvHOlFu7+KU0mljKPeL5NfxG8lhdzHw0DGsrx7ZZaZlWbP8He6C+Abwn+QX5hci4g/k7osjU0qXL7n6AwxvY82lLjWyf40wbbip+wFvDhGxA/lb+1PJ3RWdRjqCptdtPxo4P6W0eITl/8kD3xA3L3/3KpeRDN/uusAscjfkA6Q8QPIyusYLLMMd6YFHEQEcGRF3AntExHEppVPJRxc9jHxU4bylbO9h5NaiUaWU7ouI35I/yFcBnk3+1n0yucXj26XLcTNyl1znWJvhfbW0btSHdy3by35d1rSbgI2WcpsjSin9PiIuBHaNiHnk+zRaLcCYn5PfIXen7cL94/d2K/X+tIcSby9/Vx1h3mpdy4ybiNiYXO/LGPl1NhtY1DVttMel83W3Sfm7xOuDPEi8X98FjoqIbcjdW+enPHZyRCXEfor85WW9ERb5931OKV0REScCb4qID5Yw9WJyy9SHx1JkSukf3H/fj46I1wA/iYh7U0pHjWVbWjoDkZblSeRvJJdD/lYWEduSv/2/iDyAcx/yQNu3ppHHCQy7hPwN9cl91HHvUuZ1DuR9Jbnr5WxgT+BKcncMlFaFfrc9RsO383WWHAsy7I5Rpk+U48lv/C8hf2sfrvF0ugbOd1laWOp0Mvmb9vBz47qU0gURcRuwMvB87g80nYFouI53kMdmjGSoa9mx7tfRHuN+H9/vkr+5zyR3nx032oJjfU6mlM6KiHPJgeuz5H32DHI310itPt2GW6pGOlJq/a5lxkUZ53I6uaXkq8DfyC3B95GD3Y6M8NpLKY334zIWPyeHr8+QWy33GG3B0rrza2Ar8nPvLHJr8b3kAPgBlrx/3ynz3kDuZt2N3E172HLW/TNysNyd/PzRODEQaVQRsT15rMWvO5uLS9fD78pleEDwueTBfqMGopTSXRFxHLm77WUppeMnoOy3k0PX84a7KUqNq5O/oS6PfwGbRMSMju6eYY/run7x8D8jtNZ0u4H8Btd95BKRT6S4CWMfWD2S4S7O4Ra6eeQu0Nk91AgjDxjuNBxyXlQupwKklC6PiMvLtM3J9/f8jvWG99X8HuoYy36dSEeQx2S9iNyVM1Kr4bB+npPfIXe7vBjYvkzrpbsMYPgUGc+gq3u3TOtcZry8gPxesWtK6dDOGRGx28ir9Gz4gIUtWLJF6PH9bjSldHdE/AB4P7l7cYnTj3TYijyg+dMppe6jI188yjrHk1tWd4uIX5IHgP809TiYeilWJrcyLu/7mbo4hkgjinweou+Rv9F8smP6Ot3LlvEY19Nbv/YnyGMEDimHuY5020+PiP/XT93kb2yJJZ/bnxhh2lgdS34TemfnxIh4FQ/sLoM8PuR88rf8zbvmEdk68O+A+QvyOIsduhbdg3x0yXh4bfl7Tsft/gDYKiLePtIK5QiqYcNjmUY8cV9K6RJy68dryC2LnYHlZPIH+zOBU1NKneHqx+TAsG9paeiu4UEd40/Oo8f9OpFSSvPI39D3Y9njWPp5Tv6IHJLfB7yVPObqolGW7XY6uaXt9eXLCvDvIwrfQQ72Ix2BtjyGW3oe0LIT+dQNOyznto8l778PxQNP3/AQoN/3iWFfIz+Gu6cljz7tNNr9m0Pep0sorV+HkAeK/w/5C0mvoZaIeMQos95N7g79Q6/bUm9sIdIj4v7Tu6/K/WeqfiF5zM8b0gNPynhw5HOnnEQ+EmMG+ZDjx5PHFy1VSumi8qF/DHBuRPyMfCK0ReSjjV5M7lrZv8/7cwz5g///IuIw8hvYf5C/XS7vN7MvUgY2RsRTyF0gm5O7BP5KPnwfyANpy349lXw/DyN/kM8kjyPYgXwo+L5llb3Jh/j/OCK+TR6T9HTywN3LGNtrdY144Cn71yE33b+I3JLX+U344+SQclh5XM4gj/nZkPwcuIP8eJBSuinyzxm8sYxruh64LaXU2V10Cvn8VbBkINqtY5l/SyldExHvIncrXBQRh1OOIiO3vL2avL9O62O/TpjulpClGPNzMqV0a2m9eHeZ1PMHaUrp3sjnwGmBMyLia+QvNu8iv8ZenrrO0BwR7+X+cWprAffF/T/1syCltKzX9pnkEzx+OSIeTX5v2Jz8mJ9PHjvVl5TSJRHxZfLZ18+MiB+RW0jeQe5KHWk8T6/b/he9PVf+ST666yMltP8deBR5n17G6Gf3PoQcfN8GXJJS+u0YyrsgIn5P/gJzdbmN7civ5bnkIPdvJXwOD/QfHpbwyjK2C/LRvX8bw+3XZ9CHuXmZ+AtLP+y+83I7uYn3RPJYh4eNsK1Xk7+xXUn+Vn8z+XDYd9FxWHMPNa1LHqB4Djl4LSa/obbk8QYrdyw7lxEON2aUw8DJAeV88of5DeSzB68/0nbK+octZZ/t1DX9keRAMZ8cHM4gj6P6KXD7CNtZnxwULyM3y88nj6/4CrBF17KblX17CzkgnkRuaTmN5Tvs/g7yG/ingDVGWOdB5EHB55XnwK3k8V4/oOOUBmXZbcgffrcxwukAyGcATsBFXdMfSh5PkoBHjVL7tuTwcB35A/w6ckvG3ix5iH1P+5X7D7vfeITbG+t+Xeah6IxyuPNYnpMd6zyhbOsmOg43H8Nr7Pnkcz/dWi6/peP0BT08b4Yvve6jLcmnWbi5PD/+QP6AXuIxoBxKvpRaul+nQW4tvaQ8Ny4nB43hUxfs1EN9Iz42vT7e5C8JPyJ/EbiD/HrZpWO7242yrZ8xwik/eqjhE+TWvuvI74+3ko/m/BS5m3u0+zfaZZn7qPZLlB0paTlExN/JgXCJbhypHxHxOPIJOg9MKe056HrUn4g4inzqgPVT7mrVFOUYImkMImKJ87eUMURbsOTvIknL47/I3+x77i7T1FLOJfVq8mBqw9AU5xgiaWyOi4jryeOH7iKPjXgbuRm933FPEvDvI8/+kzxI/53kD9J/DrYqjVU5NcnjyGPAViL/HI2mOAORNDbHkQPQ9uSjv24Avk/+uYhrB1mYVgjrkMep3EYej/PupS+uKerd5PeJK4Cdk4OZpwXHEEmSpOo5hkiSJFXPQCRJkqpnIJIkSdUzEEmSpOoZiCRJUvUMRJIkqXoGIkmSVD0DkbQchoaGVh0aGtp3aGho1UHXItXK16HGg4FIWj6rAvuUv5IGw9ehlpuBSJIkVc9AJEmSqmcgkiRJ1TMQSZKk6hmIJElS9QxEkiSpegYiSZJUPQORJEmqnoFIkiRVz0AkSZKqZyCSJEnVMxBJkqTqGYgkSVL1DESSJKl6BiJJklS9GYMuQJKmky+fcnYadA0a1UIuHBp0DSo++MKtY9A1jIUtRJIkqXoGIkmSVD0DkSRJqp6BSJIkVc9AJEmSqmcgkiRJ1TMQSZKk6hmIJElS9QxEkiSpegYiSZJUPQORJEmqnr9l1qPFixevB6w36Do0tcyePXv1RYsWMWvWrCcuXrz4tkHXI0lTxeLFi58y6BoAZs6ceW4vyxmIevcuYJ9BF6GpZcaMGcyePRvg9EHXIklTzDmDLqDo6UdmDUS9OwhoB12EppZ77rln9UWLFp0+a9as586YMcMWojpMlTd5aap76qALGAsDUY9mzpx5LXDtoOvQ1DJv3rw1AebPn//XOXPm3DLoeiRpqui1q2qqcFC1JEmqnoFIkiRVz0AkSZKqZyCSJEnVMxBJkqTqGYgkSVL1DESSJKl6BiJJklQ9A5EkSaqegUiSJFXPQCRJkqpnIJIkSdUzEEmSpOoZiCRJUvUMRJIkqXoGIkmSVD0DkSRJqp6BSJIkVc9AJEmSqmcgkiRJ1TMQSZKk6hmIJElS9QxEkiSpegYiSZJUPQORJEmqnoFIkiRVz0AkSZKqZyCSJEnVMxBJkqTqGYgkSVL1DESSJKl6BiJJklQ9A5EkSaqegUiSJFXPQCRJkqpnIJIkSdUzEEmSpOoZiCRJUvUMRJIkqXoGIkmSVD0DkSRJqp6BSJIkVc9AJEmSqmcgkiRJ1TMQSZKk6hmIJElS9QxEkiSpegYiSZJUPQORJEmqnoFIkiRVz0AkSZKqZyCSJEnVMxBJkqTqGYgkSVL1DESSJKl6BiJJklS9GYMuoGma9wI7AVsBP2/b9o0d87YEDgGeAMwF3tu27akd818L7A+sB/wB2KVt2ysmrXhJkrRCmAotREPAZ4D/7ZzYNM1M4DigBWYD+wE/b5pm3TJ/c+Aw4N3AQ4G/AT+etKolSdIKY+CBqG3bn7VteyxwY9es7YAHA19o2/autm2PBi4AXlfmvwU4sW3bk9q2vQP4JPDEpmkePzmVS5KkFcXAA9FSbAmc37btfR3TzivTh+efNzyjbdtFwGUd8yVJknoy8DFES7EGsKBr2gJgo2XMnzURxQwNDa0KrDoR29a0Nvx8mzU0NDTQQiRpKhkaGlpz0DUAzJkz55ZelpvKgehWYK2uaWsBi3qcP972AvaZoG1r+rt60AVI0hSzcNAFFNHLQlM5EF0A/HfTNCt1dJs9CfhRx/wnDS/cNM0awCZl+kT4PHDABG1b09cschhan4kL45papsqbvDTVdTdaTGkDD0RN08wodcwAVmqaZjXgXuA04A7gI03THAg05EPzX11W/QFwVtM0LwJ+Rz4K7W9t2/59IuqcM2fOXcBdE7FtTV8d3WSLem2W1TR3oV2jUi+m23viVBhUvTc5+HycfATZHcD/tm27mByCXkUeG/Qp4NVt294A0LbthcDOwMHAzcCTgddPdvGSJGn6i5TSoGuQpq0yaHAhsNZ0+zak/nz5lLN905R68MEXbt3T2J2pYiq0EEmSJA2UgUiSJFXPQCRJkqpnIJIkSdUzEEmSpOoZiCRJUvUMRJIkqXoGIkmSVD0DkSRJqp6BSJIkVc9AJEmSqmcgkiRJ1TMQSZKk6hmIJElS9QxEkiSpegYiSZJUPQORJEmqnoFIkiRVz0AkSZKqZyCSJEnVMxBJkqTqGYgkSVL1DESSJKl6BiJJklQ9A5EkSaqegUiSJFXPQCRJkqpnIJIkSdUzEEmSpOoZiCRJUvVmjMdGIuJZwObAGSmli8Zjm5IkSZNlzIEoIo4E7kop7Vyu7w58q8y+KyJekVI6ZRxrlCRJmlD9dJk9Gzih4/pewCHAmsBPgH3GoS5JkqRJ008gWge4FiAiHg9sAHw1pXQrcDiw1fiVJ0mSNPH6CUQ3ARuV/18KXJtS+nu5vnKf25QkSRqYfgZVnwDsHxFPBHYCvt8xb0vg8nGoS5IkadL0E4g+RG4JeilwPA8cM/Qq4MRxqEuSJGnSjDkQpZQWAruMMu/Zy12RJEnSJOvnsPvVgacAjwAScB1wTkrpjnGuTZIkaVL0HIhKEDoAeBuwChBlViKff+h7wIdTSrePe5WSJEkTqKdAFBEzgJOBpwE/BU4CriKHovXJ44neBTwhIp6XUrpvYsqVJEkaf722EL0NeCrwspTSSSPM/25EvBRogbeSz0ckSZI0LfR6zqDXAUeMEoYASCmdCBwBvGE8CpMkSZosvQaiJ9Db4fQnAk/svxxJkqTJ12sgeigw1MNy15ZlJUmSpo1eA9EqwD09LHcPMLP/ciRJkibfWM5DtGNELOvEixsuTzGSJEmDMJZA9P4el0v9FCJJkjQoPQWilJK/YC9JklZYBh1JklQ9A5EkSaperz/dsYjexwallNJa/ZckSZI0uXodVP1lHCwtSZJWUL0Oqt53guuQJEkaGMcQSZKk6hmIJElS9QxEkiSpegYiSZJUvZ4CUUT8V0SsW/7fMCL8AVdJkrTC6PWw+wOBPwA3AJcDzwD+PFFFTUWLFy9eD1hv0HVoapk9e/bqixYtYtasWU9cvHjxbYOuR5KmisWLFz9l0DUAzJw589xelus1EN0EbAKcBQR1npPoXcA+gy5CU8uMGTOYPXs2wOmDrkWSpphzBl1AEb0s1Gsg+hVwRER8gRyGjo2Iu0ZZNqWUNulxu9PJQUA76CI0tdxzzz2rL1q06PRZs2Y9d8aMGbYQ1WGqvMlLU91TB13AWPQaiN4J/A7YHNiT/G34uokqaiqaOXPmtcC1g65DU8u8efPWBJg/f/5f58yZc8ug65GkqaLXrqqpotczVS8GvgsQEa8BvpBS+utEFiZJkjRZem0h+reU0qMmohBJkqRBGXMgAoiIRwJ7AM8GHgLcDJwBfDWldM24VSdJkjQJxnxixojYEjgf2J08pubU8nd34G8R8fhxrVCSJGmC9dNC9CXgMuAlKaX5wxMjYjZwUpm//fiUJ0mSNPH6+emOZwOf6QxDAOX6Z8t8SZKkaaOfQHQPsOoo81YF7u2/HEmSpMnXTyA6GfhsRGzWOTEiHgN8GvjNeBQmSZI0WfoJRHuSxx79IyLOi4hfR8RfgAvL9D3Hs0BJkqSJNuZAlFK6EtiKHHwuLtu4GPgA8ISU0lXjWqEkSdIE6+s8RCmlW4GvlYskSdK01k+XmSRJ0grFQCRJkqpnIJIkSdUzEEmSpOqNKRBFxGoRsWf5PTNJkqQVwpgCUUrpTuAzwEMnphxJkqTJ10+X2XnAFuNchyRJ0sD0cx6i9wM/jIh5wPEppdvHuSZJkqRJ1U8gOhVYBTgaICJuB1LH/JRSWmscapMkSZoU/QSiL/PAACRJkjStjTkQpZT2nYA6JEmSBma5zkMUERtExDMjYvXxKkiSJGmy9RWIIuKdEXENcAVwBvDYMv3nEfH+caxPkiRpwo05EEXEHsDXgSOAlwDRMfs04HXjUZgkSdJk6WdQ9fuAT6eUPhMRK3fNu4jSWiRJkjRd9NNl9kjg96PMWwys0X85kiRJk6+fQHQFsM0o87YFLu6/HEmSpMnXTyD6X2DviNgVWLNMmxkRLwc+DBw0XsVJkiRNhn7OQ/SliNgQOJj7w8+Z5e+3UkrfGq/iJEmSJkM/g6pJKf1XRHwVeBH5l+9vBk5JKV0ynsVJkiRNhr4CEUBK6TLgsnGsRZIkaSD6CkQRMRPYiTyIej3gWuCPwOEppcXjVp0kSdIk6OfEjJuRzzf0beDJ5BMzPhn4DnBxRHgeIkmSNK3000J0EHA38NjSbQZARGwKHEcOSi8Yn/IkSZImXj+H3W8LfLwzDAGklC4FPgk8fTwKkyRJmiz9BKIhII0yLwHX9V+OJEnS5OsnEO0HfDoiHt05sVzfr1wkSZKmjZ7GEEVE2zVpbeCiiLgAuAFYF9gSuB54DXD4ONYoSZI0oXodVL0mD+wmu5j7f7NsFWAB8Ltyfda4VCZJkjRJegpEKaXtJrgOSZKkgelnDJEkSdIKpd8zVW8A7ABsAKzWNTullN6/nHVJkiRNmjEHooh4PfB9cuvSDeSTNHZKgIFIkiRNG/20EH0OOBZ4Z0pp4fiWI0mSNPn6GUO0DnCwYUiSJK0o+glEJ+LPc0iSpBVIP11muwNHR8SDgVPI5yB6gJTSuctZlyRJ0qTpJxDNAh4M7AV8tGtekAdVr7ycdUmSJE2afgLREcCGwPvIZ6vuPspMkiRpWuknEG0DvCmldOw41yJJkjQQ/QyqvoQ+T+goSZI0FfUTiPYEPh4RjxvvYiRJkgahn5aerwCPAC6IiCGWPMospZSeuJx1SZIkTZp+AtE55CPJJEmSVghjDkQppZ0moA5JkqSBmfKDo5umOQx4Ew88vH+Ltm2vLPM3AL4LPIv8Y7N7tW171GTXKUmSpq9+fu3+0GUtk1Lapb9yRnVA27bdJ4Ec9iPgb8ArgW2B45qmuaBt2wvGuQZJkrSC6qeF6MkjTJsNbADcCFyzXBWNQdM0jyGHoP9s2/YO4LSmaVrg7cCHJ6sOSZI0vfUzhmikQEREbE5urfng8hY1gnc2TfNO4Crgq23bDrdSbQlc0bbt/I5lzwNeMAE1SJKkFVQ/5yEaUUrpQmB/4MDx2mbxNWAzYF1gD+CLTdO8psxbgyUP+19A/r01SZKknoz3oOqFwKbjucG2bc/tuPrbpmm+CbwO+ClwK7BW1yprAYvGswaAoaGhVYFVx3u7mvaGw/esoaGhgRYiSVPJ0NDQmoOuAWDOnDm39LJcP4OqHzLC5FWAzYHPARM9mPk+IMr/FwAbNU2zdtu2C8q0J01QDXsB+0zAdrViuHrQBUjSFLNw0AUUsexF+mshupGRT8wY5DE+O/SxzVE1TfN64ATgNuCZwHuB9wG0bXtJ0zRnAZ9pmubDwNOApiw33j4PHDAB29X0NoschtZnAlomNSVNlTd5aarr7sGZ0voJRLuwZCC6k/yh8KeU0j3LXdUDvRc4GFgZuBLYu+s8Q28EDgVuIp+H6F0Tccj9nDlz7gLuGu/tanrr6CZb1GuzrKa5C+0alXox3d4TIyV/hUPqV+kjXwisNd1e/OrPl0852zdNqQcffOHWPXVVTRXjdpSZJEnSdNVTl1lEXE7vP+iaUkqb9F+SJEnS5Op1DNEvWHYgegLw/B6WkyRJmlJ6CkQppT1GmxcRTwI+CWwHXEY+GkuSJGna6HsMUURsHREtcA75HERvBx6bUlrmj79KkiRNJWMORBHx9Ig4AfgTsDHwJmCLlNIPUkr3jXN9kiRJE67nQBQRz42I3wC/J/+u2GtTSk9IKR2dPHZfkiRNY70eZXYa8Bzgz8ArUkrHT2RRkiRJk6nXo8yeW/5uCRwVsdRzLaWU0rQ6XbckSapbr4FovwmtQpIkaYB6PezeQCRJklZY/nSHJEmqnoFIkiRVz0AkSZKqZyCSJEnVMxBJkqTqGYgkSVL1DESSJKl6BiJJklQ9A5EkSaqegUiSJFXPQCRJkqpnIJIkSdUzEEmSpOoZiCRJUvUMRJIkqXoGIkmSVD0DkSRJqp6BSJIkVc9AJEmSqmcgkiRJ1TMQSZKk6hmIJElS9QxEkiSpegYiSZJUPQORJEmqnoFIkiRVz0AkSZKqZyCSJEnVMxBJkqTqGYgkSVL1DESSJKl6BiJJklQ9A5EkSaqegUiSJFXPQCRJkqpnIJIkSdUzEEmSpOoZiCRJUvUMRJIkqXoGIkmSVD0DkSRJqp6BSJIkVc9AJEmSqmcgkiRJ1TMQSZKk6hmIJElS9QxEkiSpegYiSZJUvRmDLmC6WLx48XrAeoOuQ1PL7NmzV1+0aBGzZs164uLFi28bdD2SNFUsXrz4KYOuAWDmzJnn9rKcgah37wL2GXQRmlpmzJjB7NmzAU4fdC2SNMWcM+gCiuhlIQNR7w4C2kEXoanlnnvuWX3RokWnz5o167kzZsywhagOU+VNXprqnjroAsbCQNSjmTNnXgtcO+g6NLXMmzdvTYD58+f/dc6cObcMuh5Jmip67aqaKhxULUmSqmcgkiRJ1TMQSZKk6hmIJElS9QxEkiSpegYiSZJUPQORJEmqnoFIkiRVz0AkSZKqZyCSJEnVMxBJkqTqGYgkSVL1DESSJKl6BiJJklQ9A5EkSaqegUiSJFXPQCRJkqpnIJIkSdUzEEmSpOoZiCRJUvUMRJIkqXoGIkmSVD0DkSRJqp6BSJIkVc9AJEmSqmcgkiRJ1TMQSZKk6hmIJElS9QxEkiSpegYiSZJUPQORJEmqnoFIkiRVz0AkSZKqZyCSJEnVMxBJkqTqGYgkSVL1DESSJKl6BiJJklQ9A5EkSaqegUiSJFXPQCRJkqpnIJIkSdUzEEmSpOoZiCRJUvUMRJIkqXoGIkmSVD0DkSRJqp6BSJIkVc9AJEmSqmcgkiRJ1TMQSZKk6hmIJElS9QxEkiSpegYiSZJUvRmDLkBj8+VTzk6DrkEjWsiFQ4OuQR0++MKtY9A1SJo+bCGSJEnVMxBJkqTqTfsus6Zp1gYOBrYHFgFfbNv2K4OsSZIkTS8rQgvRN4BVgUcC/wF8rGma7QdbkiRJmk6mdSBqmmZ14HXAx9u2vaVt2/OB/wV2GWxlkiRpOpnWgQjYDFipbdsLOqadB2w5mHIkSdJ0NN3HEK0BLOyatgCYNd43NDQ0tCq5a07SNDA0NLTmoGuQajZVXoNz5sy5pZflpnsguhXo3uFrkQdXj7e9gH0mYLtjsuPmcwZdgjRddH9ZGhe+BqWeTchrsA89nZNsugeii4HUNM3j27b9e5n2JOCC0Vfp2+eBAyZgu5reZgFXA+szMUFc0rL5OtRyi5Sm94mPm6b5IbA68FZgI+BkYOe2bU8YaGGqQmkSXgis1WuzrKTx5etQ42G6D6oG+H/AYuBa4DfAFwxDkiRpLKZ7lxlt2y4gH3ovSZLUlxWhhUiSJGm5GIgkSVL1DESSJKl6BiJJklQ9A5EkSaqegUiSJFXPQCRJkqpnIJIkSdUzEEmSpOoZiCRJUvUMRJIkqXoGIkmSVL1IKQ26BkmSpIGyhUiSJFXPQCRJkqpnIJIkSdUzEEmSpOoZiCRJUvUMRJIkqXoGIkmSVD0DkSRJqp6BSJIkVc9AJEmSqmcgkiRJ1TMQSZKk6hmIJElS9QxEkiSpegYiSZJUPQORJEmqnoFIkiRVz0AkSZKqZyCSJEnVMxBJkqTqzRh0AdIgNE1zGvB04B7gLuAs4L/atr14Obd7GHBd27YfXd4apZo0TfNMYH9gqzLpUuCTwO3AUW3bPmJQtakOthCpZnu0bbsGsAEwDzh0wPVIVWqaZk3gV8AhwMOAhwMfAG4ZZF2qiy1Eql7btrc3TXMU8GOApmk2A74JbE0OSvu3bfvdMm9f4HFt276xXF8NuAN4FPAy4M1AaprmvcC5bds+t7zZfxF4Bfk19xPgQ23b3tk0zUPJQey5pZyLgZe3bXvjxN9zacrYDJjZtu3h5fo9wBlN06wFXAes2jTNrWXe04B/Ah8GdgfWAs4A3tO27RBA0zRzgYOANwEbAicDu7Ztu6C8Zr8D/Cf59TgX2LFt239M9J3U1GYLkarXNM0scpC5tGmamcAvgT+Qv6W+Cdi/aZoXLWs7bdt+C/ghcEDbtmu0bTsccr4HrAZsATwOeAzwiTLvQ+TX4SPJ34zfA9w5TndNmi4uBu5smubIpmle0TTNOgBt2y4EtgduKK+pNdq2vRB4O/m18jJgfeBayheaDjsBryzzVwW+Vqa/ndwttwmwNvBG4OaJu2uaLmwhUs0OaJpmf2BN4DLgVcC2wGxgv7Zt7wXObprmEPKb6MljvYGmadYFGuAhbdsuKtM+AxwOfBy4G3gosGnbtn8DzlnueyVNM23b3lLGEH2E3Dq7ftM0pwO7jbLKW4AD27b9J0DTNB8G5jdNs0nbtpeVZb7Rtu2/yvyPA39ummYn8mtuFvnLyZ9LwJJsIVLV9mzbdi1yi8195e8jgatLGBo2t0zvx8bAysBVTdMsaJpmAbkFat0y/3+A3wE/bZpmqGmaL5ZWKqkqbdte3LbtO9q23Qh4NDm4fH+UxR9Jfl0Or3srcBMPfJ1e2fH/FcAqwDplm4cDBwM3NE1zcOnWVuVsIVL12ra9tGma9wPfBd5A/na6ckco2hi4pvx/K/DgjtW7j3xJXdevJI+HWLdt27tHuO1byd+KP9I0zSbACcBFpRapSm3bXtE0zdeBH7Hkawry63Hj4StN06xBbmm9pmOZDbv+XwzMa9v2PuCzwGebplkPOIY8HukTqGoGIglo2/aEpmmuJx+KvwD4RNM0nwO2BHYljzEC+Avw8aZpHg1cD+zTtanryd9uh7d7XdM0vwK+2jTNx8q21wce37btiU3TvII8fuJS8hE1i4F7kSrSNM3jyIOcjwauIrfkvIM8lu96YHbTNLPbtp1fVvkh8MmmaU4gf+nYn9z9dVnHZt/TNM0vgRuBzwBHt217X9M0zyePGbqA/AXnLnzNCbvMpE77A3uSx/w8B7iB/Ab98bZtTwJo2/YU4AjyWJ8LWHJc0XeBxzRNM79pmt+WaW8nB53zgIXAr8lH1QBsCpwILAL+BpzE6N0E0opqEfmozt+TQ8p55e/byzihH5APeljQNM3m3N/l9WtgiHzqjDd0bfMIoAWuJgee95fpjyC/rheSxw5eQ+66VuUipZFaIyVJmp7KYfe7t2174qBr0fRhC5EkSaqegUiSJFXPLjNJklQ9W4gkSVL1DESSJKl6BiJJklQ9A5EkSaqegUiSJFXPQCRNUxGxfUQcHxHzImJxRFwfEb+KiB0jYqWIOCwi0jIup5VtnTbK/G903N7TI+KEiLguIu6IiLkR8ZOI2HaC7+d2pZatJ/A2vhIRc/tY77SI+OU43P7aEbFvRGzR5/o91VH244f6uQ1pRedvmUnTUER8DtgL+DnwXuBa4OHADuSfObgZ+DTwnY7VPgE8jvt/lw3y76cNOxPo/rC8rtzes4DTyD8zsntZ7zHl9rYB/rS896lya5N/F+8C4B+DLUWqk4FImmYi4uXkMLRfSmnfrtnHRMRXgcUppcvIv9U0vN48YKOU0h9H2fSCpcx7NzAX2CGlNPxDmKcCB0WELc2Spj3fyKTpZ09yi9BnRpqZUvpzSukv43ybs4EbOsJQ5+3dt7QVI+JZEXF6RCyMiEURcX5EvL1rmZdHxJkRcXtEzC9dQE/uriEijizbuCIiPjLCbT0jIk6NiNvK7R0ZEet2LTMnItpyW9eMsp19I+LWEaYviIh9l3F/N4+IX5Tbv610Y26ylOU3Bi4vV4/p6K7cuMz/Qtlnt5Z6fxQR642yrbdFxGWlS/O0iHjs0mot67w8Iv5U1pkXEd+OiNWXtZ60ojEQSdNIRMwAngWcmlK6Z/w3HzM6Lx3zzgGeGRGfjojHjWGDawK/Inex7UjuYjuY3EU0vMwbgOOAG4A3kbv0zgQe2bW57wAXA68qy+8fES/t2M4zyN16C8m/fP5O4GnAL7q284sy/d3Ae8r2XtvrfVqaiHg0+RfbHwLsVO7POsApEbHqKKtdC7y6/P8x4Bnlcm2Zti7wOeDl5F9s3xj4v67HB+Ap5JbDjwJvA9YDfr2U2yUiXkv+RfjzyfvhI6WW7/Zyf6UVSkrJixcv0+RCHieUgM93TQ9yF/jwZaUR1j0MuGCU7Z5Wttt9Wb/MnwWc1DH9JuCHwHOWUe/WZfmtRpkfwFXAiUvZxnZlG1/sWu9y4JCOaf9HDlLRMW0L4D7gZeX6S8u2XtCxzFrkwDa3Y9q+wK0j1LIA2Ldrv/2y4/rh5G7K1TqmrQMsAt6zlPu4canrtcvYnyuTg2ICXtJVx73AYzqmbVqmvatjWgI+1LEP5wJHdt3GS8s+e/ygn+9evEzmxRYiaXrq/hHC1wCLOy5f62ObvyO3nHRergdIKS1KKb0E2Bb4FHAe8DpyS8U7lrLNy8hh49sR8fqIWKdr/mOB9YFDe6jvpOF/UkoJuLCsS0Q8mNxydgywckcL18XkwPW0suq2wMKU0qkd21oInNzD7ffiJeQWl3s6apgP/KWjhjGJfDTh7yNiIXAPcHWZtVnXoheklC4ZvpJSuhT4K/k+j2QzYCPgx12tgv9HDkQTdlSfNBUZiKTp5SbgLkoQ6HAK94eYa7tX6tHClNLZXZfFnQukPD5pn5TSC8lh5mpg/9E2mFKaD7yY3ELyfeC6MrZlq7LIQ8vfoR7qW9B1/W5gtfL/bHLryYE8MBguBjYENijLrQfMG2Hb1/dw+714GLDHCDU8p6OGnkXE08gBawh4K7kr7ell9mpdi98wwiauJ9/n0WqFfKRiZ623k/flmOuVpjOPMpOmkZTSPRFxJvDCiFg5lUHOJXicDRARd09SLZdHxDHAnhHx8JTSiKEipfRnYPuIeBDwfOBLwLHAJuSABzBnOctZQG41+1zZdrcby99ryV1Y3R7edf1OYGbnhIiYCayxjDpuJo+Z+tYI8xYtY92RvIo8Jur1qQxej4iNRll23RGmPZzcmjeSm8vf9zLyaRN6CanSCsNAJE0/BwC/JA/A/fRk3OBSAs9m5BarBcvaRkrpDuD4csTVVyNiNeAicivTzsCP+60vpXRbRPwB2DyltPdSFv0zsFZEvGC42ywi1gJexP0BgVLTKhGxScqnLwB4AbnlZGlOBrYE/pJGOCJvKYZDbHerz4PIrTadXaRvZmRbRsSmpauMiNgUeCJw0CjL/5N8Px+dUvrmGGqVVkgGImmaSSn9KiK+AHwqIp4EHE1u+ViL3DXzCPprjVia/y3jS34KXAKsST4y6xXAV1JKd420Ujln0q7kbpkrS23vA85MKd1ZlvkQ8KOI+ClwBDlgPQM4K6U0lrNAfxg4NSKOBo4ij91Zn9xl972U0mnkE0ueC/wwIv6bHOT24oEnqAQ4Abit3O/9y3beT245Wpp9gLPIR3cdTO6yegTwPOCMlNKPRlnvulLLjhFxOXkf/A34DbkL7usR8XPyfnnrKNu4HjguIj5Zrn8auIY8mH4JKaUUEXsCR5bD7H9V7vNG5CPaPpZSungZ91daYRiIpGkopbRXRPwO+H/k7pm1yC0c5wC7kAPBePom+VDuj5HHpNxOHjC9K/nIqtFcSh6g+1lyl85N5MHRe3Xcl6Mj4nbg46XuO8mh5edjKTCl9PuIeDawH/A9YBVyC8gppY7hEPBK8iH8B5FD09e5/yzfw9u6KSJeA3yZ3AV3Xrn/py2jhksjYhvyOaK+Re5iuxY4nRxwRlvvvojYmdzldwqwKvColNLxJbi9j9yKdiY5hI4UVM4lB9Yvkh+jPwG7jxZWy+0eExELyPv+LWXyXHJwHK9xVdK0EPlgDUmSpHp5lJkkSaqegUiSJFXPQCRJkqpnIJIkSdUzEEmSpOoZiCRJUvUMRJIkqXoGIkmSVD0DkSRJqp6BSJIkVc9AJEmSqmcgkiRJ1TMQSZKk6hmIJElS9QxEkiSpegYiSZJUPQORJEmqnoFIkiRVz0AkSZKqZyCSJEnVMxBJkqTqGYgkICJ2iIj39LnuxhGxb0TMGe+6JEmTw0AkZTsAfQUiYGNgH8BAJEnTlIFIkiRVz0CkakTE4yPi+Ii4KSJuj4iLIuIjEXEY8Hbg8RGRyuWwss4zIqKNiKGIuC0izouIt3Zsczvgt+XqWcPrl3k7lesP66rjvOHtL62uCdwVkqQuMwZdgDSJjgOuB3YFFgKbAusDnwbWAR4HvLksO6/83Qg4E/gOcCfwLOC7EbFSSulw4Fzg/wHfBHYG/jmOdUmSJomBSFUorTSPAt6fUjquTP5tx/x5wEYppT92rpdSOqpjmQBOJ4eVdwGHp5RuiYh/lEUuSCmdPZ51SZImh4FItbgJuAL4fEQ8BDglpXT1slaKiNnAfsArgUcCK3dsb2B1SZLGl2OIVIWUUgJeAlxI7t66KiLOjojnLmPVw4AdgS+V9Z8GHAqsNuC6JEnjyECkaqSULk4pvQ6YDWwH3AUcFxFrjLR8RKwGvAL4TErp6ymlU0uXWK+vmzvL31W6ps9enrokSePPQKTqpJQWp5T+D/gCsCb5/EF3s2Srz6rk18jdwxMiYhbQdC03PL97/eGur8071t8c2GAMdUmSJoFjiFSFiHgC8GXgaOAyYC1gL2BuuX4hsEtE7AhcAtyYUpobEWcBHy2Dru8BPko+Emzdjs1fDNxb1r8HuKe0JP0JuAo4MCL2Ioecj9Ix/qiHuiRJk8AWItXiunLZCzgBOIgcVl6SUroX+C5wDPB14Cxg37Lem4BLgcOBrwE/AY7o3HBK6UbyoffPA84o65NSWgy8itx1dky57T2Ba8ZQlyRpEkQe0ylJklQvW4gkSVL1DESSJKl6BiJJklQ9jzLTCu/Vpx06IQPlfrbdLjER251sV773sROyfzb8xkUrxP4ZT18+5ewJ2dcffOHW7mtpOdlCJEmSqmcgkiRJ1TMQSZKk6hmIJElS9QxE0oBExO4RcdpS5h8VEftOxLY1fiLijxGx06DrmCwRsVNE/HHQdfSitsdGy8dAJE2AiDg2Iu6OiHUGXctUEhGnRcSdEXFrRNwUESdGxGaDrmtFFBFzI+KlXdO2i4jrBlWTNJUZiKRxFhHrAi8HFgFvHnA5U9EeKaU1gA2AecChA65HkgxE0gR4C/kHYf8H2Hl4YkRsGBGnRMSiiDgT2KhzpYh4fkT8vcw/Alila/5/RMTZEbEgIs6NiOf0uu2pKKV0O3AU8GSAiHhERBwdEddHxFURsW9ErFTm7VS6P74QETdHxNUR8YqyTy4q++RLw9uO7CMR8a/SEnVsRMwp8z4SEb/qrKVMO778v0pEfC4iLo+IGyPiyIiY3bHsG8t253fe5nRTWpA+GBHnRMQtEXF81/3cJiJOL/fzuojYq2v9z5Z9e01EvLlj+vbl+XlLeRw/3TFv44hIEfHWsn/nR8SBHfNXKo/xvIi4MiJ2KctvXOZX8dhoMAxE0vjbGfgB8ENgq4h4Spn+I+AiYB3gv4Bdh1eIiIcAvwC+AMwGTgGajvlPBI4E9gAeAnwSODYiHrasbU9VETGL3IJ2aQk+LTlIbgRsC7ySB96PpwJXAOsC+wPfI+/rbYCnAO+MiGeWZd8OvAd4GbA+cC3w4zLvSOBFXd2ZbyY/ZgCfL9vbltyKdTfwjVLz48gtWu8sdSwAtl6uHTFYbwFeBcwB1gY+ABAR6wO/Id/XhwObAad2rPdU4Loy733AQRGxZpl3G7BT2d7LgN0i4rVdt/siYMuynZ0j4gVl+q7Aa4CnAVsA23etV9Njo0lmIJLGUURsDTwe+GFK6SrgdPIb/obAM4C9Ukp3ppTOIQemYa8ALkkpfT+ldE9K6XDg/I757wIOSSn9LqV0X0rpl8B5wMt62PZUc0BELARuIYeZt5A/uDYA9i73YQg4ANixY71rUkrfTindQ75/DwO+klJamFL6F/BH8oclZZsHppT+mVK6A/gwsG1EbJJSuho4E3g9QERsCTyaHDAD2B34QErphrLuJ4DXRcTKZZ0TUkonp5QWkz+g50/MbpoUX00pXZlSuhX4CQ/cf2eklA5LKd2dUrolpfSnjvWuSSl9vTxXfwbcRw5NpJROTyn9rTxPzyeH9ed13e4+KaXbyuN2esft7lhqmltq2m94hQofG00yA5E0vnYGfpdSmluufx94E/AoYGFKaWHHsld0/D8HuLJrW53zNwbeV7qGFkTEAuDpZb05y9j2VLNnSmkt4DHkD9LHkO/fOsD8jvv3TXILxLDOwcC3jzJtjfL/I4G5wzPKh+tNZTrk1qDhbp43Az8vXXjrAA8G/tBRx/mlzkfQ9TillO4FrhnLnZ9Ei4GZXdNmlunDRtt/G5Jb60bTPTD73+tGxLYR8dvS7bUQeDc5vI62fuftzgGu6pjX+f+K9NhoCvK3zKRxEhGrkr/hrhr3H8kzg9zFtTGwVkSsmVK6pczbsGP1oa7rw/PPK/9fCXwxpbTvCLe74TK2PSWllC6NiPcD3yV3k1ydUtp4nDZ/DXmfAxARawAP5f4PyJ8A34iITcmBdbcy/UbgDuBJHaGWju0MAU/suL4y94esqeZKchDv9Gh6C8tXAs/u83aPBL4NvCyldEcZI7Rej+sOkVsKh3X+vyI9NpqCbCGSxs8O5IHQWwFPKpctyd07byB36XwuIlaNiCfzwCPQfgVsFhFviogZEfHWsp1hB5PHyDy7DDx9UORB2OunlK5cxranrJTSCcD1wDOBeRHxiYhYvdzHx0REd1dLr34I7BERm0XEauQxR39OKV1WbvcW4JfAt8itJqeU6fcBBwEHRsR6kI8ajIhXlu0eA2wfES+IiJnAf5PHfE1FPwTeHxFbRrY5sCc5sPSy7nPL4OeZEbFmRGzb4+3OAuaXMLQ1OXD26mhyS+hGJcR+YnjGCvbYaAoyEEnjZ2fgiJTSv1JK1w1fgAOBlwAfIo8vupE8EPTfh5unlG4iD27dmzzu4cXAcR3zzyUPFP4fctfPFcAHuf81/KbRtj0N7E/eNw25++wS8j74Mb23LHQ7nBwif839rQ5v6FrmB+T9fFTpXhn2UeCvwBkRsQj4PXmsEymlC4F3kFu1biC3Op3dZ40T7Xvkbsefksdr/YL8vPjOslYs499eSh6zM488YH+7Hm/3PcAny77blxxUenUIeXD92cCF3D+Q+67yd0V5bDQFRUpp0DVIE+rVpx06IU/yn223S0zEdifble997ITsnw2/cdEKsX/G05dPOXtC9vUHX7j1CrmvS2vnn4DVSguRNGFsIZIkTQnlPEP/WbqN1yEfKXasYUiTwUAkSZoqgvu7jf9JPtv7ewdakarhUWaSpCkhpXQX+aSL0qSzhUiSJFXPQCRJkqpnIJIkSdXzsHtJklQ9W4gkSVL1DESSJKl6BiJJklQ9A5EkSaqegUiSJFXPQCRJkqpnIJIkSdUzEEmSpOoZiCRJUvUMRJIkqXoGIkmSVD0DkSRJqp6BSJIkVc9AJEmSqmcgkiRJ1TMQSZKk6hmIJElS9QxEkiSpegYiSZJUPQORJEmqnoFIkiRVz0AkSZKqZyCSJEnVMxBJkqTqGYgkSVL1DESSJKl6BiJJklQ9A5EkSaqegUiSJFXPQCRJkqpnIJIkSdUzEEmSpOoZiCRJUvUMRJIkqXoGIkmSVD0DkSRJqp6BSJIkVc9AJEmSqmcgkiRJ1TMQSZKk6hmIJElS9QxEkiSpegYiSZJUPQORJEmqnoFIkiRVz0AkSZKqZyCSJEnVMxBJkqTqGYgkSVL1DESSJKl6BiJJklQ9A5EkSaqegUiSJFXPQCRJkqpnIJIkSdUzEEmSpOoZiCRJUvUMRJIkqXoGIkmSVD0DkSRJqp6BSJIkVc9AJEmSqmcgkiRJ1TMQSZKk6hmIJElS9QxEkiSpegYiSZJUPQORJEmq3v8HViPCb04vjHIAAAAASUVORK5CYII="
+     },
+     "metadata": {
+      "needs_background": "light"
+     }
+    }
+   ],
    "metadata": {}
   },
   {
@@ -636,7 +725,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "source": [
     "p = (\n",
     "    pd.concat(\n",
@@ -662,7 +751,20 @@
     "p.save(out_dir / \"3_id_changes.png\", width=4, height=4, dpi=300)\n",
     "p.draw();"
    ],
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ],
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmgAAAJECAYAAACigdgEAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8/fFQqAAAACXBIWXMAAA9hAAAPYQGoP6dpAABT9klEQVR4nO3debx1Y/3/8dcHd6YfUhQ3iUqRVF9SGhSpaLqShm9z0qy5lDQYimb1LSqVStIgUa5GFd3KPEUqYzLeEglxG25cvz+utdm2fe6zzz7nOOuc/Xo+HvuxzlnrWmtda5+9znmfa13rWlFKQZIkSe2x1ExXQJIkSXdnQJMkSWoZA5okSVLLGNAkSZJaxoAmSZLUMgY0SZKkljGgSZIktYwBTZIkqWUMaJIkSS1jQJPmmIULFy67cOHCPRYuXLjsTNdFGkWeg5oKBjRp7lkW2L2ZSrr3eQ5q0gxokiRJLWNAkyRJahkDmiRJUssY0CRJklrGgCZJktQyBjRJkqSWMaBJkiS1zDIzXYFBpJR2BTYFHgc8GDgz5/zYJZTfHNgLeAJwB3Ac8MGc85/7lJ0PfAp4NvD/gL8An8o5H9ZT7gHAvsAzgUXAgcAeOefbesr9BFg+57ztMMcqSZI0W1rQPgFsCZwL3LCkgk04WwCsB+wG7AE8Ajg2pfTInrL3A44Ftge+CrwLuBH4cUrp1T2b/jbwNOBjwEHALk357u09H9gWeNvEDk+SJOkus6IFDXhozvlCgJTSReOU/RJwK/DUnPPlzTo/As4GPgc8p6vsB6lBLuWcf9aU/SZwAvD5lNJhOedFKaXlqcHr9TnnA5tya1GD3T7N9ytQW9j2zjn/fdJHLEmSRtasaEHrhLPxpJQeBmwGHNoJZ836lwOHAtuklFbvWuUVwN874awpezs1aK1GDWVQH9exFHBN17rXACt2fb8HcBPwmcGOSpIkqb9ZEdAmYLNmekKfZSdSj3cTgJTSmsBazfx+Ze/cXs75WuAcYOeU0iNSSk+hhrvjm209Cng38Nac861TcSCSJGl0zbWANr+ZXt5nWWfeWkOUBXg9sD41qP0RuBjYI6UUwP7AD3POC4artiRJ0l1mSx+0Qa3QTG/ps+zmnjITKUvO+fiU0nrARtS7OM/NOd+RUnoDsCHwwuamg/8Dng5cBXwi53zokMcyroULFy5LvfwqdVupM124cOGMVkQaUZ6DWqL58+dfP16ZuRbQFjXTfqFluZ4yEykLQM75ZuC0zvdNf7ZPU4fwuCql9Cvg/tSbBx4PHJJSuiTnfNJED2RAuwK7T9O2B/aDs/0F1FKXzXQFdJeXbzh//EJD8hxsLc/BlpnO83CCYrwCcy2gdX5LrdVnWWfe5UOUHcvnqJc8D2jGU9sWeGbO+WTg5JTSy4AdgekKaJ8EPj9N256I62a6AtIssMo0bttzUBrMdJ6HU2quBbRTmukTgQN6lm1OHbT2dICc8xUppcub+b06804da0cppacBLwc2zTmXlNLazaJLu4pdCjxoQkcwAfPnz7+F/pdo713+9y6Na5BLGkPzHJQGMq3n4RSbUzcJ5JwvoIaqlzQtWsCdTwt4CfDbnPNVXav8AHhoM8Bsp+zSwDuow2j8ut9+Ukr3oQ5s+8Wc81nN7M5vyI27im7cNV+SJGkgs6IFrRnV/8HNt6sAy6aUPtJ8f3HO+btdxd8F/B74Y0pp32beO6jXe3fu2fSnqMHt+ymlz1Mvab6cOrzG63LON45RpfdTx0DbozMj53xZSmkB8MUmEG5KvaHApwpIkqQJmS0taK8HPt687gus0fX967sL5pyPB7aiDoOxF/XRTOcBW+Sc/9JT9t/Ak4EjqEHqS9S7b17aeWJAr5TSQ4APA+/sE+BeQb3M+rFmu6/POR8zzAFLkqTRFaWUma6DZrl9jjrVD5E0jvdt/bhx79oaluegNJjpPA+n2mxpQZMkSRoZBjRJkqSWMaBJkiS1jAFNkiSpZQxokiRJLWNAkyRJahkDmiRJUssY0CRJklrGgCZJktQyBjRJkqSWMaBJkiS1jAFNkiSpZQxokiRJLWNAkyRJahkDmiRJUssY0CRJklrGgCZJktQyBjRJkqSWMaBJkiS1jAFNkiSpZQxokiRJLWNAkyRJahkDmiRJUssY0CRJklrGgCZJktQyBjRJkqSWWWamK6DhLV68eE1gzZmuh6TxLV68eJOZroM06tpyHs6bN+/08coY0Ga3NwO7z3QlJA3ktJmugKTWnIcxXgED2uz2NSDPdCVozwdearNNp3HbnoPSYKbzPJxSBrRZbN68eVcAV8x0PSSNb5BLGpKm12w6D71JQJIkqWUMaJIkSS1jQJMkSWoZA5okSVLLGNAkSZJaxoAmSZLUMgY0SZKkljGgSZIktYwBTZIkqWUMaJIkSS1jQJMkSWoZA5okSVLLGNAkSZJaxoAmSZLUMgY0SZKkljGgSZIktYwBTZIkqWUMaJIkSS1jQJMkSWoZA5okSVLLGNAkSZJaxoAmSZLUMgY0SZKklllmpiswHVJKqwG7AAl4EHAd8Gfg8znnI3vKPgf4KPBo4Gbgd8AHcs4X95R7JvAZYH3gPOD9OeejesqsDZwNvDHn/MNpODRJkjQC5lwLWkppeeA44O3AkcA7gS8CDwF+nVJ6RVfZ7YGfA8sB7wc+B2wJHJdSWqOr3IOBI4CrgJ2Bq4GcUlqnZ/dfAo43nEmSpMmYiy1ozwMeDrw75/zFzsyU0jeBy4E3Ad9PKc0D9gUuBbbIOd/QlPsVcBqwG7BTs/q2zXS7nPOilNJB1JC2DfCNZr3nAs8GNp7ew5MkSXPdnGtBA1Zppgt75l8D3ALc2Hz/NGA+cEAnnAHknM8AFgAvSykt3cxeHrg557yoKbOIejl0RYCU0grAfsAnc84XTPHxSJKkETMXW9AWALcBn0wp3QCcBdwf+AA1kH6qKbdZMz2hzzZOBJ4OPAw4tymzakppF+AHwCuBVbvW3Q24Ffj0FB+LJEkaQXOuBa1pwfpfar+yX1IvYZ4BPBV4Ws75j03R+c308j6b6cxbq9nmScBewCeAi5uv98o5n5RS2gh4L/DWnPMtU35AkiRp5MzFFjSo/cPOBg6mtoY9EHgf8IuU0tY5578AKzRl+4Wqm5tppww554+mlPaj3mxwYc75ypRSAPsDh+Scj04pPZXaQrcucCrw9pzzJVN+dJIkaU6bcwEtpfR44CjgbTnnr3fN/wn1cuV+1Ds1FzWLlu2zmeWa6aLumTnnK4Eru2btCGwEvKi50/NI4PPA4cCe1ED4mJzzHZM8rL4WLly4LP3rL6llFi5cuPJM10EadW05D+fPn3/9eGXmXEAD3kY9rh93z8w5/yuldCywbUppGe66iWAtamtbt7Waab/Ln8CdY619Gti12faHqMNwfCTnXFJK7wbOB55A/35uU2FXYPdp2rakqXXdTFdAUmvOwxivwFwMaJ3xy5bus2yZZn4ApzTznkgdnLbb5sC1wJLuyPwsNYB1WunWBi7POZfm+0ub6YOYvoD2SWqL3UxrywdearNVxi8yNM9BaTDTeR5OqaECWkSsAzwWOL2UclnX/I2olxAfC1wEfKCU8ttJ13Ji/gY8C3gtdeBZAFJK6wJbAGfmnBenlI4BrgDekFL6Qtc4aI+hXgL9Rs759n47SCltQb2Tc7OuQLYQeGlKadnmZoGNu+ZPi/nz599C/z50966zp+0QpTljkEsaQ/MclAYyrefhFBu2BW1n6qXER3ZmRMSK1JaoBzazHgPkiHh0KeX8SdVyYr5IDWefTik9itp6tQbwVup4Zh8BaELau4BDgD+mlL4BrAy8h9rPbM9+G28GuN0f2DfnfGbXokOow20cllL6JfVJBucDJ035EUqSpDlt2GE2ngqcX0o5t2veK6jh7KfUFrTdqB3Y3z6J+k1Yzvkiajj8JvAkamB7D3Am8Iyc8y+6yh5KfV7nLdTWtl2AY4An55yvGGMXOwMr0dP3K+d8PvBC6h2cn6aGvOfnnBdP0aFJkqQREaWU8Uv1rhRxJXBaKeU5XfMOA7YD1imlXN7MOxu4rZTi44/msH2OOnXiHyJpxLxv68eN2yl4WJ6D0mCm8zycasO2oK1KfXRSt82Bv3XCWeMsaud5SZIkDWjYgHYjsHrnm4hYF1gTOK6n3G3MzTtFJUmSps2wAe1vwFMiohPSXgEU4I895R7E3Qd2lSRJ0jiGbd36DnX8sFMj4nTgOcB/gdwpEBHLAZsAR0+2kpIkSaNk2ID2DWqfsx2orWT/BXYspfy3q0yiDmvxh8lUUJIkadQMFdBKvfVzx4jYnTq0xjmllBt6ip1HHXbixMlVUZIkabRMqgN/KeVS7nqkUe+yM4AzJrN9SZKkUTSpgBYRSwH3o94g8J9Syh1TUitJkqQRNuG7OCNi3Yj4YkT8DVhMvUvzX8CtEfGXiNgnIh401RWVJEkaFRMKaBHxFuBc6uObNgCi67UU9dmc7wbOj4jXT2lNJUmSRsTAlzgj4n+BrzTfLqQ+HPw04GpqOFuNOqzGS4H5wNcj4tpSymFTWmNJkqQ5bqCAFhHLAvtS+5p9FvhIKeW2PkUPjogPAJ+gPlR8v4j4WSnl1qmqsCRJ0lw36CXOF1FbyA4upXxwjHAGQCnltlLKB4CDgQdQh9qQJEnSgAYNaM+ktp7tMYFtd8puO4F1JEmSRt6gAe1/gPNLKf8YdMOllAuB84HHDlEvSZKkkTVoQFsTOGeI7Z9DvWFAkiRJAxo0oK0MXDfE9q9r1pUkSdKABg1oywK3D7H9O4D7DLGeJEnSyJrwkwQkSZI0vSbyLM5tI+LoCW5/wwmWlyRJGnkTCWhrNK+JKkOsI0mSNLIGDWh7TmstJEmSdKeBAlopxYAmSZJ0L/EmAUmSpJYxoEmSJLXMQJc4I+Kpk9lJKeUPk1lfkiRplAx6k8AChr8bs0xgP5qAxYsXr0l9DJekllu8ePEmM10HadS15TycN2/e6eOVmUhwiiHrMex6Gt+bgd1nuhKSBnLaTFdAUmvOw3Gz0aB3cdpXrZ2+BuSZrgTt+cBLbbbpNG7bc1AazHSeh1PKS4+z2Lx5864Arpjpekga3yCXNCRNr9l0HtoyJkmS1DIGNEmSpJYxoEmSJLWMAU2SJKllDGiSJEktY0CTJElqmYECWkSsExH3m+7KSJIkafAWtH8An+18ExHfiogdp6dKkiRJo23QgBbc/bEEOwBPmfLaSJIkaeCAtgi4/3RWRJIkSdWgj3o6G3hGc1nzgmbeGhHx1EFWLqX8YZjKSZIkjaJBA9pXgG8C3+iat03zGk+ZwH4kSZJG3kDBqZTy7Yj4F/BiYB1gK+BfwDnTWDdJkqSRNHDLVinlF8AvACLiDuBXpRTv5JQkSZpiww5U+x3g2KmsiCRJkqqh+oaVUl431RWRJElSNenO+xGxObVP2lrNrMuB35dSTpzstiVJkkbR0AEtItYBvgc8qTOrmZZm+XHAq0opl0yqhpIkSSNmqIAWEfcFfg+sB9wMHAn8vVn8EGBb6pMGjoqIx5VSrpt8VSVJkkbDsC1o76OGs18CbyqlLOxeGBFrUMdMe05TdrfJVFKSJGmUDHsX5wuBq4CX9oYzgFLKP4H/Ba4Gth++epIkSaNn2IC2HnBMKWXRWAWaZcc0ZSVJkjSgYQPa7cC8AcotA9wx5D4kSZJG0rB90M4HtoyI+5ZSru1XICLuRx1+47wh9zEpKaXVgY8CzwfmA/8B/gS8O+d8ble55zTlHk294eF3wAdyzhf3bO+ZwGeA9anH9P6c81E9ZdamPlj+jTnnH07ToUmSpDlu2Ba0Q4FVgF9ExEa9CyNiY+DnwMrAIcNXbzgppYdSw1iiPvXgrcDngOuA1bvKbd/Uczng/U2ZLYHjUkprdJV7MHAEtd/dztS+dTmltE7Prr8EHG84kyRJkzFsC9oXqTcBPBE4MyL+BPyjWfYQ4LHU8HcGNbTc275HDVNPyzlf369ASmkesC9wKbBFzvmGZv6vgNOod57u1BTftplul3NelFI6iBrStqHerUpK6bnAs4GNp+WIJEnSyBiqBa2UchPwdOBHzaxNgRc3r02aeYcAzyil3DzZSk5ESmkr4AnAbjnn61NKy6aUlu1T9GnUS58HdMIZQM75DGAB8LKU0tLN7OWBm3POi5oyi6iXQ1ds9rkCsB/wyZzzBdNyYJIkaWQM/SSBUsp/gJdFxIOAp3L3Rz39oZRy6RTUbxid1q7rUkp/oA6YGymlM4AP5pyPbJZv1kxP6LONE6kB9GHAuU2ZVVNKuwA/AF4JrNq17m7ArcCnp/ZQJEnSKBq2D9qdSimXllK+V0r5TPP63gyGM4CHN9MfU/ucvYzaB2014JcppWc0y+c308v7bKMzby2AnPNJwF7AJ4CLm6/3yjmflFLaCHgv8Nac8y1TfCySJGkETfph6S20UjM9B0g55wKQUjoK+BuwN/VOzRWacv1CVeeybKcMOeePppT2o/axuzDnfGVKKYD9gUNyzkenlJ4KfApYFzgVeHvO2WeRSpKkCZmLAe2mZnpQJ5wB5JzPTykdD2yRUloR6Ayy269/2nLN9G4D8eacrwSu7Jq1I7AR8KLmTs8jgc8DhwN7Ar9IKT0m5zwtY8EtXLhwWfrXX1LLLFy4cOWZroM06tpyHs6fP7/vDYzd5mJA61ye/GefZVcAQR0ipPOIqrWoY5d16+5P11dKaTVqn7Ndc87/Sil9iHrn6EdyziWl9G7qeHFPoH8/t6mwK7D7NG1b0tS6bqYrIKk152GMV2AuBrSTgTcDa/dZtjZwG3ANcEoz74nUS57dNgeuBZZ0R+ZnqQHs613bvryr1a7TD+9BTF9A+yS1xW6mteUDL7XZKtO4bc9BaTDTeR5OqbkY0I6gjtP2hpTSATnn2wBSSo+hhrGjc843p5SOobaovSGl9IWucdAeQx2s9hs559v77SCltAX1Ts7NugLZQuClKaVlm5sFNu6aPy3mz59/C/370N27zp62Q5TmjEEuaQzNc1AayLSeh1Ns0ndxtk3O+d/ALtSx2Y5JKb0jpbQ7cDS1f9r7m3KLgXdRW7j+mFLaKaX0QeA31H5me/bbfjPA7f7AvjnnM7sWHUJ9csJhKaWdgIOoLWwnTf1RSpKkuWzOBTSAnPNXqMNr3If6/Mz3AscBT2wGou2UO5T6OKhbqI952gU4BnhyzvmKMTa/M/VO0bv1/co5nw+8kHoH56epIe/5TRCUJEkaWJRSxi8lLcE+R53qh0gax/u2fty4nYKH5TkoDWY6z8OpNqkWtIjYIiJ+FBGXRcQtEfHNrmXPjIhPRMQaS9qGJEmS7m7ogBYRH6E+s/LF1FH553H320avo14y3H4S9ZMkSRo5QwW0iHg28DHqOGEvBR7YW6aUcjJ1XLDnTaaCkiRJo2bYYTbeRe1Y/+xSyl8BIvpe1j0TWH/IfUiSJI2kYS9xbgac3AlnS3AVYB80SZKkCRg2oK1I/0cp9VplEvuQJEkaScOGpyuBhw1Q7hHc9cgjSZIkDWDYgHYs8NiIePJYBSLiedQQ9/sh9yFJkjSShg1o+wAFODwitouIu91sEBHbAgcAi4F9J1dFSZKk0TJUQCulnA68D1gNOAy4lhrYXhQR1wK/AB4AvK+U8rcpqakkSdKIGLoDfynli8BzgFOA5amD1K5EfWD4WUAqpew3FZWUJEkaJcOOgwZAKeVI4MiIuD+wHjXwXVpKGetB45IkSRrHpAJaRynl38C/p2JbkiRJo84xyiRJklpmqBa0iNhtwKK3AlcDp5ZSzhhmX5IkSaNm2Euce1Dv2hxPdMpFxJnADqWUPw+5T0mSpJEwbED7GLAOsAOwCPgtcBE1jK0LPBNYATgQuAN4CvBY4HcR8T+llMuHr7IkSdLcNmxA+zpwOnAo8LZSytXdC5u7Or8MPBfYlPrczi8Db6SOn/beYSssSZI01w17k8DHgduAV/eGM7jzrs7XUJ8k8PFSym3UUHYNsM2Q+5QkSRoJwwa0bYFjSym3jlWgWXYs8Kzm+xuBM4AHD7lPSZKkkTBsQLs/9ekB41kOuF/X9/+axD4lSZJGwrBh6RJgy4h4wFgFmmVPBy7rmv0A4D9D7lOSJGkkDBvQDqE+d/N3EbF178KIeDr1zs4VgR828wLYGDhnyH1KkiSNhGHv4vwktbP/44DfRMTV3H2YjdWpY6Cd2pQF+B/qkBw/Gb66kiRJc99QAa2UsigitgT2At5ADWSrdxVZBBwAfLiUsqhZ53TqA9UlSZK0BEM/LL0JXu+NiA9Rxzpbu1l0OXBaKeWmKaifJEnSyBk6oHWUUm4GjpuCumiCFi9evCaw5kzXQ9L4Fi9evMlM10EadW05D+fNm3f6eGUmHdA0o94M7D7TlZA0kNNmugKSWnMexngFJh3QImID4BHAymPtsJRy0GT3o76+BuSZrgTt+cBLbbbpNG7bc1AazHSeh1Nq6IAWEZtTn8m50ZKKUe/sNKBNg3nz5l0BXDHT9ZA0vkEuaUiaXrPpPBwqoEXEw7lrnLMTgAdS79D8IbA+8FhgaeqQGtdPRUUlSZJGxbAD1e5CDWc7lVKeDPwRoJTyylLK46ljnp1BDWtvn4J6SpIkjYxhA9pWwN9LKfv3W1hK+SvwPOChwIeH3IckSdJIGjagrQn8pev72wEi4j6dGaWUK4BjgO2Hrp0kSdIIGjag3QTc1vX9f5vpA3vKXQ88aMh9SJIkjaRhA9rlwDpd31/QTJ/YmdE8HH0T4D9D7kOSJGkkDRvQTgIeGRHLN9//upl+ISKeGxEbA1+l9kE7ZZJ1lCRJGinDBrRfAstRbwSglPJ36phoa1IHTj0DeBNwK/CRSddSkiRphAw1Dlop5XBgXs/stwHnAy8B7gecDXyiuaNTkiRJA5qyZ3GWUu4APt+8JEmSNKShLnFGxFObpwmMV279iHjqMPuQJEkaVcP2QVtAfZrAeD4A/H7IfUiSJI2kYQMa1AehS5IkaYpNJqANYlXg5mnehyRJ0pwy8E0CEbFOz6z/12de93Y3Ap4F/H3IukmSJI2kidzFeRFQur5/UfNakgAOnmCdJEmSRtpEAtol3BXQ1gEWAVePUfZW4DLgMOoTBSRJkjSggQNaKWXdztcRcQdwaCllx+molCRJ0igbdqDa13HXA9IlSZI0hYZ91NN3proikiRJqib9qKeIWBq4P/Xh6X2VUi6Z7H4kSZJGxdABLSI2Az4GPA1YdglFy2T2I0mSNGqGCk4RsTlwNHe1mv0HuH6qKiVJkjTKhm3Z2pMazr4FfLiUcuXUVWlqpZQ2BM4A7gO8MOf8057lrwHeC2wAXAtkYNec8797yr0C2A1YG/gT8M6c8596ymwCnAQ8Led8/DQcjiRJGgHDPurpCcC5wBtbHs4C+BqweIzl7wG+Qw1m7wS+DrwC+H1KaYWuck+gDrh7BrAzNZz+IqW0UleZpZp9fdtwJkmSJmPYgLYMcEYppYxbcmbtCGwKfLZ3QUppNWAv4BRg65zz13POuwEvBzYG3t5VfDvqkxRennPeH3gpsCaweVeZnYAHA7tM+VFIkqSRMmxAOwdYbSorMtVSSqsDnwH2Bi7uU2Q7YAVg35zz7Z2ZOeefARcCr+oquzxwbc65E0ivaaYrNvtakxr2ds45/2cKD0OSJI2gYQPa14EtIuKhU1mZKfY56qOoPjfG8s2a6Ql9lp0IbJRSWr6rzGNTSq9OKT2YGsZuBU5rln8B+FPO+aApqbkkSRppQwW0UsrXgR8Av42I5zRjobVGSmkr4DXA23POt45RbH4zvbzPssup782azfc/Ag5qXhcBbwTelXO+NKX0LOCFwFunpvaSJGnUDTvMxoXNl+sCPwNui4grgDv6FC+llHutpS2ltCywP/CjnPNvl1C0cxPALX2W3dxdprm0uUNK6aPAWsB5OedrUkrLAV8GPpNzPiel9CLgw8ADgAXUOz2vucfWJUmSlmDYYTbW7fo6gHnAOmOUvbdvJPggtXXs6eOUW9RMlwVu6lm2XE8ZAHLOlwKXds36MPX4927u9DyUejfoycB+1Ds/nzPB+g9s4cKFy7LkQYIltcTChQtXnuk6SKOuLefh/Pnzxx07dtiAtt6Q602rprP+rtQWtOVTSg9rFj2gma7RzLsYWNjMW4t7Pvh9LWpr4BVL2NcjgA8AKed8c0rp9cDxOef9muUfAn6bUloz5zzmdiZpV2D3adq2pKl13UxXQFJrzsMYr8CwD0vvd1dkGzyQ2qL0rubV66vNdEPq8BpvAp7IPQPa5sDfcs69LWu92/ppzvnI5vu1uXvrWufrB7GEoDdJnwQ+P03bnoi2fOClNltlGrftOSgNZjrPwyk1156R+Q/gJX3mbwm8jTrsxinUmwCOAL4EvD2l9P3OUBsppecDD6G2TvWVUno1dXy1DbpmL6QO4Nuxcdf8aTF//vxb6N+H7t519rQdojRnDHJJY2ieg9JApvU8nGKTCmgRsTJ1vLAnAasDR5VSPtMsezi1r9ofSik3j7mRKZRzvg74ce/8lNL/a748oetRT/9tOv1/DvhdSukH1Eub7wP+Sg1v95BSWrVZ5yM9ly4PBl6fUjqIGgI/CPw+53zZpA9MkiSNlGHHQSMinkUd0HVf6uORnsHdW5QeAfwKSJOp4HTKOe8DvA64HzWQvRX4IbBVznnRGKt9inr58ss921oAvJ56yXQv4FTgldNScUmSNKfFME9riogNqQHkPtTnTx4DHAIcWErZsSlzH+DfQC6lGFTmsH2OOrXtj/ySZtz7tn7cuJ2Ch+U5KA1mOs/DqTbsJc4PUYeieEkp5XCAiDiku0Ap5daIOAN4zKRqKEmSNGKGvcS5FXBmJ5wtwWXcNRq/JEmSBjBsQFsdOG+AcsvQPFBckiRJgxk2oF1HveNxPA8B/jXkPiRJkkbSsAHtdGDTiBjr8U5ExKOo/c9OGnIfkiRJI2nYgHYA9SaBH0TEGr0LI2K1pkw0U0mSJA1oqIBWSvkx9cHgTwT+HhG/aRY9OSIydXy0xwPfL6UcOcZmJEmS1MfQA9VSB6f9ZPP1M5rp+sDzqOOj7QPsMIntS5IkjaShH/VUSrkd+HBEfI467MZDqIHvUuojn7w5QJIkaQiTflh6KeU/wHjjoUmSJGlAk7nEKUmSpGkwVECLiJdHxIURse0SymzblHnx8NWTJEkaPcO2oL0cuC9w9BLK/B5YFfBB6ZIkSRMwbEB7NPDnUsqtYxUopdwCnIkPS5ckSZqQYQPaGsDlA5S7vCkrSZKkAQ0b0BYB9x+g3P2BMVvZJEmSdE/DBrS/Up8acL+xCjTLngKcM+Q+JEmSRtKwAe0wYEXg4IhYoXdhRCwPfBdYHvjx8NWTJEkaPcMOVPs14I3ANsB5EfF97mop24B6l+d84FzgK5OtpCRJ0igZKqCVUm5qxkA7HNgUeF9PkQD+BLywlLJoclWUJEkaLZN5FuelEfF44PnAtsCDm0WXAL8GcimlTL6KkiRJo2WogBYRrwFuKaUcAuTmJUmSpCkw7E0C3wZ2mMJ6SJIkqTFsQPs3cM1UVkSSJEnVsAHtJOrjniRJkjTFhg1onwE2jIg3T2VlJEmSNPxdnAHsD3wlIl5EHbj2IuCmfoVLKX8Ycj+SJEkjZ9iAtgAo1KD2DGDrJZQtk9iPlmDx4sVrAmvOdD0kjW/x4sWbzHQdpFHXlvNw3rx5p49XZtjg9Adq8NLMejOw+0xXQtJATpvpCkhqzXkY4xUY9kkCWw6znqbc12jHGHRt+cBLbbbpNG7bc1AazHSeh1PKS4+z2Lx5864Arpjpekga3yCXNCRNr9l0Hk5JQIuI+wD3pz5dwPHRJEmSJmHYYTYAiIhXRcTJwI3AZcDnupa9MCK+HxHrTbKOkiRJI2XogBYRBwDfAR5HHV6jt8PbecDLgBcNXTtJkqQRNFRAi4hXAjsCfwE2A1bpLVNK+Su1Ve3Zk6mgJEnSqBm2D9qbgBuA55VSLgWI6HvH6FnAhkPuQ5IkaSQNe4nzMcBJnXC2BNcADxxyH5IkSSNp2IC2LHDdAOVWB24fch+SJEkjadiAdjnjXLqMes3zkcA/htyHJEnSSBo2oB0FbBARL1hCmVcDawO/HXIfkiRJI2nYgPY54Bbg+xHx7oiY31kQEfeLiLcAX6GOj/alyVdTkiRpdAwV0Eop5wOvbdbfB7iU+vD01wJXAV+m3iG6QynlkqmpqiRJ0mgYeqDaUsqhwOOBQ4H/UgeqDeBm4GfAE0sph01FJSVJkkbJpJ7FWUo5C3hZc0PA/amB7+pSyh1TUTlJkqRRNKGAFhEPA7YH1qX2QTsD+FEp5Sbg6qmunCRJ0igaOKBFxLuBzwBL9yz6eEQ8p5Tyl6msmCRJ0qgaqA9aRDyFejPAMsAi4E/A36k3BqwNHBYRQ/dnkyRJ0l0GDVVvp94A8B1gjVLK40opDwc2oQa1hwHbTk8VJUmSRsugAe2JwGXAm0spN3ZmllL+DLyLGt42n/rqSZIkjZ5BA9oDgVNLKbf2WXZsM33A1FRJkiRptA0a0O4DXNtvQSnl+q4ykiRJmiQ79kuSJLXMRMZBe1hEvGaY5aWUgyZWLUmSpNE1kYD25ObVT1nC8gIY0CRJkgY0aEC7hBq0Wi+ltAnwSuDpwHrA7cB51Ae4fy/nXHrKPwf4KPBo6nNEfwd8IOd8cU+5Z1IH6l2/2d77c85H9ZRZGzgbeGPO+YdTf3SSJGkUDNQHrZSybillvWFf030QPT4AvAY4CdgF+BhwB/Bd4IDugiml7YGfA8sB7wc+B2wJHJdSWqOr3IOBI4CrgJ2pj7XKKaV1evb9JeB4w5kkSZqMuXiTwJeAtXPOb8k5fy3n/EVgC+AYYMeU0qMAUkrzgH2BS4Etcs5fyTl/EtgGWBPYrWubnUF4t8s57w9sRx37bZtOgZTSc4FnA2+bzoOTJElz35wLaDnn43POt/TMuwM4rPn2Uc30acB84ICc8w1dZc8AFgAvSyl1nju6PHBzznlRU2YR9XLoigAppRWA/YBP5pwvmIbDkiRJI2QiNwnMdms306ua6WbN9IQ+ZU+k9mF7GHBuU2bVlNIuwA+ofdxW7Vp3N+BW4NNTX21JkjRq5lwLWj8ppTWBNwEXA39sZs9vppf3WaUzby2AnPNJwF7AJ5pt7AXslXM+KaW0EfBe4K29LXeSJEnDmPMtaCmlZYFDgZWBF+ecO4+rWqGZ9gtVN/eUIef80ZTSfsBDgAtzzlemlALYHzgk53x0SumpwKeAdYFTgbfnnC+Z6mPqWLhw4bLAstO1fUlTZ+HChSvPdB2kUdeW83D+/PnXj1dmTge0lNIywI+AJwFv6hkWY1Ez7RdwluspA0DO+Urgyq5ZOwIbAS9q7vQ8Evg8cDiwJ/CLlNJjmj5w02FXYPdp2rakqXXdTFdAUmvOwxivwJwNaE0H/+8DCXhnzvmAniILm+la1LHLuq3VTPtd/uxsfzVqn7Ndc87/Sil9iNq/7SM555JSejdwPvAE+vdzmwqfpAbCmdaWD7zUZqtM47Y9B6XBTOd5OKXmZEBLKS1FHffsJcDOOed9+xQ7pZk+kTo4bbfNqQ+HX9IdmZ+lBrCvN9+vDVzeNRDupc30QUxTQJs/f/4t9L9Ee+86e+H4ZaQRN8gljaF5DkoDmdbzcIrNuZsEmnD2beDlwIdyzvuMUfQY4ArgDSml/9e1/mOog9UeknO+fYx9bEG9k/MtXYFsIbB+0+cNYOOu+ZIkSQObiy1on6U+SeAU4NKU0qt6lv855/znnPPilNK7gEOAP6aUvkG9keA91H5me/bbeDPA7f7AvjnnM7sWHUIdbuOwlNIvgbdTW9hOmrpDkyRJo2DOtaABmzbTzaiXOXtf23cK5pwPpfZRu4X6mKddqC1rT845XzHG9ncGVqKnc37O+XzghdQ7OD9NDXnPzzkvnoqDkiRJoyNKmRXPQFeL7XPUqX6IpHG8b+vHjXvX1rA8B6XBTOd5ONXmYguaJEnSrGZAkyRJahkDmiRJUssY0CRJklrGgCZJktQyBjRJkqSWMaBJkiS1jAFNkiSpZQxokiRJLWNAkyRJahkDmiRJUssY0CRJklrGgCZJktQyBjRJkqSWMaBJkiS1jAFNkiSpZQxokiRJLWNAkyRJahkDmiRJUssY0CRJklrGgCZJktQyBjRJkqSWMaBJkiS1jAFNkiSpZQxokiRJLWNAkyRJapllZroCGt7ixYvXBNac6XpIGt/ixYs3mek6SKOuLefhvHnzTh+vjAFtdnszsPtMV0LSQE6b6QpIas15GOMVMKDNbl8D8kxXgvZ84KU223Qat+05KA1mOs/DKWVAm8XmzZt3BXDFTNdD0vgGuaQhaXrNpvPQmwQkSZJaxoAmSZLUMgY0SZKkljGgSZIktYwBTZIkqWUMaJIkSS1jQJMkSWoZA5okSVLLGNAkSZJaxoAmSZLUMgY0SZKkljGgSZIktYwBTZIkqWUMaJIkSS1jQJMkSWoZA5okSVLLGNAkSZJaxoAmSZLUMgY0SZKkljGgSZIktYwBTZIkqWUMaJIkSS1jQJMkSWqZZWa6AjMtpbQU8C7gzcB6wL+AHwK755wXdZV7D/BO4H7AccDbc84X9mzrBcAPgEf1LpMkSRqULWjwBeDzwN+AtwOHAu8GjkgpBUBK6SVNmV8CuwLrA4c34Y6mzIrAvsBehjNJkjQZI92CllLaCHgHcHjO+UVd8/8BfAl4CfAjYHvgmJzz25rlZwNHAw8Fzm9W2xO4AfjsvXYAkiRpThr1FrSXAwH8X8/8bwCLgFc13y8PXNO1vPP1igAppUdTL3++Nee8eLoqK0mSRsOoB7TNgDuAk7tn5pxvBs5olgOcAGybUnp2Smk9YDdqSDu3uQy6P/D9nPMx91bFJUnS3DXqAW0+cHXO+ZY+yy4H1kgpLU293PkHah+0C4GtgR1zzjcBbwQeAex871RZkiTNdSPdBw1YAegXzgBubqbL55xvoLagPRS4P3B2zvm/KaUHAJ8C3p9zvjqltBOwE7ASkIEPNCFuWixcuHBZYNnp2r6kqbNw4cKVZ7oO0qhry3k4f/7868crM+oBbRHwgDGWLddM7wxYOee/A3/vKrMP8FfgWyml/22+fz1wKXAgsDQ1sE2XXYHdp3H7A3n5hvNnugrSbHDddG3Yc1Aa2LSdhxMU4xYopdwbFWmllNKRwDOAFXovc6aUjgMeknNec4x1twKOBDbJOf8lpfQb4F8551c1y99AHXZjxZzzHdNRf1vQNIaVgMuAtYH/znBdpFHkOaglsgVtfKcAzwIeD/yxMzOltBzwWOpQGveQUroP8FXgCznnvzSz1wZO6yp2KbUVbjXq4LdTbv78+bcw9iVajaiFCxd2vvzvIL8EJE0tz0FNhVG/SeAQoFAHpu32Rmr/tO+Nsd4u1PC1Z9e8hcDGXd9vDNwKXD0VFZUkSaNjpFvQcs5npZS+DLw9pXQ49S7NDaljmh1NDXB309wo8CHgpd2PggIOpvZF+z9q0/ZHqUNvTMvlTUmSNHeNdEBrvBu4CHgT8FzgKuCL1Gdx9uug92Xg1znnn/XM/w6wJvBW6gC2P6U+41OSJGlCRvomAWkuam4jvw5Yxf4v0r3Pc1BTYdT7oEmSJLWOAU2SJKllDGiSJEktY0CTJElqGQOaJElSyxjQJEmSWsaAJkmS1DIGNEmSpJYxoEmSJLWMAU2SJKllfNSTJElSy9iCJkmS1DIGNEmSpJYxoEmSJLWMAU2SJKllDGiSJEktY0CTJElqGQOaJElSyxjQJEmSWsaAJkmS1DIGNEmSpJYxoEmSJLWMAU2SJKllDGiSJEktY0CTJElqGQOaJElSyxjQJEmSWsaAJkmS1DIGNEmSpJYxoEmSJLWMAU2SJKllDGiSJEktY0CTJElqmWVmugLSXJdS2hL4fc/sG4C/At8AvpVzLtNch+2Ax+ac95jO/UizTUrpYcCuwBbAg4BFwELgROArOec/pZTuC7wbWJBzXjAzNdWoMaBJ956DgSOpLddrA28ADgDmAx+f5n1vB7wW2GOa9yPNGimlzYBjgFuA7wB/A1YCHgFsC5wL/Am4L7B7s9qCe7ueGk0GNOnec1rO+eDONymlbwEXAO9LKX0i53z7zFVNGkm7A8sDm+ec/9y9IKW0FHD/GamVhAFNmjE553+mlM4GHgesDvwTIKX0NOCjwOOp5+hfgc/nnH/QvX5KqQDfyTnv0DN/D+ofnvVyzhellBYAT+tap2OrzuWalNIGzTpPp7YWXAp8F/hEznlx17YfBewJPJH6x+sa4C/AXjnnYybzfkgz4GHAv3vDGUDO+Q7gqp4uCrunlDotacfknLcESCmtSD1nXwqsBfwb+CXw0ZzzFZ1tppR2AL4NPIt6Tu4ArEY9hz6Uc/5Ndx1SSq8D3gasDyxN/R1xHLBTzvnGyR262s6bBKQZklKaR+3zcgdwbTPv+cBRwMOBzwIfof5i/n5K6f1D7mpv4I/N16/uep3d7HMz4GRqINwPeCf1ss9uwCFd9V0NOBr4n6bcW4EvAjcCmwxZN2kmXQjcP6W0/RLKnA28p/n6J9x1/uwNd57HRwK7UM+j9wCHUbsUnNicN70+Q+128H/U7g0PAH6RUtq6UyCl9BrgW8AV1D5y7wV+RD3XVprwkWrWsQVNuves2PyyDmow2wV4IHBozvnmlNLS1OBzPfD4nHOnRe0rwPHAXimlg7v/Ix9Ezvm3KaVXAlt0X2Lt8k3gEuAJXf+Vfy2ldCbwxZTSVjnn3wNPorb0PS/nfPIEj11qo72BZwCHpZTOA44FTgKOzjlfAJBzvjKl9FPgC8Cf+5xDOwBPBj6Zc/5QZ2ZK6Vjgh9SW6Xf0rHNf4NE55/82Zb8NnAN8CdioKbMdcHbO+fk9634IjQRb0KR7z17AVcC/gNOAl1Avd+zYLN8UWAc4oBPOAHLONwP7APcBnjuVFUopbQxsDHwfWD6ltFrnBfy6KfbMZnpdM31BSmm5qayHNBNyzsdRW46/R71kvyPwNeD8lNIvUkoPGGAzLwRuAz7ds+1DgPOb5b3274SzpuxC6jn4yJTS+s3s64C1UkpPmdhRaa6wBU2693wVOJwatDYBPgisCXT6eK3XTP/aZ93OvIdMcZ02bKZ7N69+HgiQcz4mpfRd6n/w700pnQj8BvhhzvkfU1wv6V6Rcz4DeBXcOeTGVsBOwHOowe2ZY65crQdclnO+rs+yv1H/oblPzvnWrvnn9Cl7djN9CDXYfYLaT+2PKaUrqHeP/pLa4n7L+Eem2c4WNOnec17O+Xc551/mnPcCXkm9lf9jU7yfpSdQtvM74DPUP0T9Xvt0CuecXwM8mjpcxyJqx+izU0ovm3StpRmWc74g5/wNYHPg78AzUkoPmqG6nE/9B+p51EulG1Jv3DlrwJY9zXK2oEkzJOd8RErpN8C7U0pfpXZYBnhkn+KdeRd2zbsGWLVP2X6tbGMNhHt+M12cc/7dOFUGIOd8FnAW8OnmD8VpwKeof0SkWS/nfEvTB/Oh1HEK/7mE4hcCz0oprdR92bLxSODyntYzgA2AI3rmdVqz7zzHm5ayXzQvUkovp14K3QnHNJzzbEGTZtbHqJc8PwScTu2sv2NKafVOgZTSstQ7uG6l+UXdOB94Ykpp+a6y61I7F/e6oVneG+hOp16G2alfS0FKabmU0krN1/drxoa6U875X8DlOF6UZqGU0jObm3N6569GvSnmNup5dkOzqN8/RD+lNnbs3LONl1CHx/hJn3Xe0jmvmrLzgVdQbwo4v6sOvf7UTD3fRoAtaNIMyjkfl1I6hnon2N7A26m/0E9JKX2DehnxVdQ+ax/ouYPzy8BBwO9SSt+j3mH5VmrgelzPrk5qtr1fSunX1H5vR+ec/9Xczn8U8JeU0jep/WNWpo6m/iJge2r/l9dQW/t+Qh1g93bqeE5PoPavk2abLwD3SykdQW0VvoXap+w1wBrU8f2uAUgp/R14WUrpApqbfXLORwMHUs/f3VJKD6WOU7YB9Vy8hDpuYK9rgRNSSgdS/0F7C7AC9XFSHb9JKf2HOkTOpdTx0t5ADY13GxNRc5MBTZp5e1M72++ac35LSukZ1L5dH6Seo38BXplz/n7PegdTh+vYifqH5mzqH4XHcM+A9gPqXaIva15LUTtD/yvnfFpK6X+ADwMvpv5hupZ6qeULQGcQzwXUoPh86s0Nt1H76bwT+Mok3wNpJryX2uL8ZOogsytTP/unA+/LOR/aVfbV1PPhM8By1LECj845L04pPYs6buBLm9c11P5iH8k5X91nvx8AtqQGstWoNwG9qWeg2q8223oLteXu38CpwGtzzsdP7rA1G0Qp0/qMZkmSxN2eJHDnUzyksdgHTZIkqWUMaJIkSS1jQJMkSWoZ+6BJkiS1jC1okiRJLWNAkyRJahkDmiRJUssY0CRJklrGgCZJktQyBjRJkqSWMaBJkiS1jAFNkiSpZQxo0hwQEVtGxDci4m8R8Z+IWBwR/46IkyNiv4h4RkREU3aPiChDvLZs1j9wgLI/7VPH7SIiR8TCiLg1Iq6LiAsi4tcR8dGI2OhefdOWoHk/S0QsmOm6AETEDk19Dpyi7a3bbO+iqdjeTImIi5rjWHeC63U+wztMT82kyVtmpisgaXgRsRrwPeBZzazLgeOA64BVgEcBb2tefwI2Ac4AvtNnc9sCDwTObMr0+mfP938Hjh2jaqd31XFp4LvAy5tZfwVOBm4C1gGeCmzT1HfnMbanWaoJT/8ALi6lrDuztZFmDwOaNEtFxH2pAekRwDnATqWU3/cp9yjgPcDLAEopPwV+2qfcAmpA+2kpZY8BqnBsKWWHAcq9hRrO/gu8oLeOEbEC8Dxg3gDbkqSRYECTZq99qeHsQuBJpZT/9CtUSvkL8PqI+Nq9WbkuL2um+/ULkKWURcCP7t0qSVK72QdNmoUi4qHAK5pv3zNWOOtWSjl5ems1pgc2039N5UYjYtOIOCQiLmv6tF0fERdGxGER8YIlrPOdiPhHRNwcEddExJkR8dmIePAY68yLiF0i4q8RcVPTt+/wiNhwCXVbNSL2jIgzIuK/EbEoIs6KiI80LYb91lkmIt7dlLs5Iq5qjmXjJeyn059wjzGWD9WXLiKWj4j3RcSJEXFtU59zI+IzEXH/CWznQOrlTYAH9/ZV7Cq3UkS8sXlfz4+IG5vXWRGxd9NaPN6+XhgRxzafg/9GxIKIeM5EjrtrW5tGxPci4pKIuKX5nBw57PakYRjQpNnpedTz9z/Az2e4LuO5pJnuEBGrTMUGI2Jr4ATgpcDVwBHA74CrgOcCr+uzzvupfd9eA9zarHMs9dLqzsBWfXY1D/glsFtzHL8AbgReCBzfr3N6RDyS2o9vN+ABzT5+B6wOfBw4rvd9iIilgEOBLwAPB44BjqL2GTwZ2GyAt2VKRMR84CTgc8D6wCnU92BZ4P3AqWOF2T6OBQ5rvr6R2vex+9XxGODrwFOofR1/1qy7JvAh4JRxguE7gcObOv4c+BvwNOAXEfGOAesKQES8i/qevwL4N5Cp/Sa3bLa320S2Jw2tlOLLl69Z9gIOAgrwuync5oJmm3uMU+7AptyBA253u6Z8Aa6l3jDwVuAJwH2GrOvRzfZe2WfZKsDmPfNSU/4m4KV91nkksGHX91t21fl0YI2uZcsBv26Wfa1nO8sDFzTLPt59fMAKwPebZd/qWe9tzfx/9tRjGeArXXU5sGe9PZb0M+s6jgU989dt5l/UMz+owagABwAr9dTlc82yoyfws+q7r54yawNbA0v1zF+BGuQK8OU+613ULLuj97MA/G8zfzHwqDE+wzv0zN+mWecq4Kk9yzYGLm3We9pUnXe+fI31sgVNmp1Wa6ZX9VsYEY9phhLofT1lCuvw2t5LVr2XruDOmxJeT22NWAV4FTV0nAhc11zGm2gLUeey6S97F5RSriulnNgze89m+uFSyj36u5VS/lZKObvPfgrwulLKP7vK3gzs3nz7jJ7yrwUeCvy8lPLRUsqtXestAt5EvdT76ohYtWu9dzfTPbrrUUq5DXgv97yDdrpsAzyZehfvW0op/+2pyweAvwBbNTefTIlSymWllKNKKXf0zF9EDfO3AS9ZwiaOKKV8r2fdQ6itastQW9gGsSc1pL6llPKHnu2dRf1ZAEyoVU4ahjcJSHPTg6hhodcCxh4aY6KWNMzG3ZRSvhURP6Remt0KeBzwaGpr1PbACyLiLaWUAwbc98nUVq/vRcQngBObAHEPEbEG8Fhqy8g3B9x+xyWllDP7zO+EqLV65j+3mR7Sb2OllBsi4lTgOdTLlr+JiLWAhzVFDu6zzs0R8SMGDxmT0an/Yf3ez1LKHRHxB+rwLU+ihrUpExFPAragDr+yAjUsQb0kvXpErFr697fsN2xMZ/6LqC2J4+17NeDx1FbWn41RbEEzfdJ425Mmy4AmzU5XN9PV+y0spfycu/64ERG/o15CmkqDDrPRqVPnbs0fNXVaEXg28AlqX6cvR8SvSymXDbC5XakB79nN66aIOJ36B/R7Pa1h6zTTK0op1w1a38Yl/WaWUq6POu7vsj2LHtJMvxsR3x1n252f3drN9OpSyg1jlP3HGPOnWqf+H4+Ij49Ttu9nbxgR8QBqX7XxWnhXpva77DXW+9OZv/YYy7utRz1nlgduaX6+Y5myY5fGYkCTZqfTgVcDm0TEUr2XhmaDUsqNwI8j4gTgPGqLybOBbwyw7j8j4nHUjuDPoF6We0Iz/VBE7FpK+fQUVHOi72un28ivgSvHKXvxxKszYRPtxtIpfyy1hXRJ/jrx6ozpAGo4O4F6+fhM4D+llMUAEbGQesPAElPTEgyyXufYb+CuGxukGWNAk2annwP7AKtSL5e1/U7OMZVSLo+Iv1Eve642Xvmu9Qq1xWwBQEQsB+wAfBn4RET8uJTyd+5qBVszIlYZohVtIi4FNgC+WUr58YDrXN5MV4uI/zdGK9q6Y6zb6eO20hjLB73bsuPSZnpEKeVzE1x3KE1L6nOoYfg5pZRr+yxfY5zNrEcNdb3WbaaDtMp2jr0AO87Gf3o0t3iTgDQLlVIu4K5+Tp+fquErpkOMc60o6qOgOn25BvlD2lcp5eZSyv7An6m/2x7dzP8n9Y/3UsCOw25/QL9qpi8ddIXmku6Fzbev6F0eEcsydgf5Trgba0y2544xfyyd+r9kvJ/bBHRC5FgNAqsASwPX94azxqsYvwXs1WPMf00zXTDO+pRSFlI/OytRH3smzSgDmjR7vY06pMP61DG5ntavUDNW1yB9cKbLz6MO9Dq/d0EzAOlXqZevrueugLBEEbFzRKzTZ/4G1PcD7n4JsXMX594R8aI+6z0yljDw7AR8vdnvSyLi0xFxj5atiFgjIt7YM/v/mukezTF0yi5NHdriHu9d42hqy9M23T//qN5J7SA/EUdQxz17PPDtiLhHX6uog/C+JSIGvQJzFTWkrRER9+uz/Epqv7L7RsTdglZEbA58coB9vDAiXtY9IyJeTD3+26hP3RjER5rptyPi+b0Lm/f1CRHxrN5l0lTzEqc0S5VS/hMRT6aOrbU1sCAiLqMOkXAttbPz+tTxmwI4Czh1Bqq6FvAp4JMRcQ5wLnAz9bLVZsCK1DvnXlNKuXrMrdzdR4DPNts7u1l/PrUf0zLAQaWUOx/YXkr5SUR8GNiL2u/tHGqr2vLUOygfSR3ctt9QGwMrpdwYEc+lXnL+APCmiPgztWVwBeogtBtSh9ro7mv3ZeCZwPOBMyPi99TQ8gRqeP0qdbiJ3v1dGhH7Au8CjoqIPwLXUAd+XYf6vn9wAvW/IyK2ow7I+1rgxRFxJvUy8X2oNxFsTG3xOpAafsbb5uKIyMCLgTMi4lhgUbPsDaWU2yPiY9RBeg+KiLdRWxTXod4teTDwVJZ8ufaLwA8i4r3A+dShTp7QLNu5lPLnAY//Z81AtfsAOSIuoH5er6PeGPAY6uDDnwZ+M8g2paHN9EBsvnz5mvyLGtC+SX1o+nXUwTmvAU4D9qd2pF9qnG0sYHoGqn0o9YHpP6IOy3A19Q/7tdTA+GngwRM83lcC36KGzn9TA99F1HHRtgNijPU2pwbay6itOv+mBtpPA+t0lduSPgO89myr0HSF67NsJeqo+8dTg9atwELq8CCfAZ7YZ51lqONs/bU5nqupD7V/DLVvXd/3nBq+30sdPf8W7hr9fpOxjoNxBo+l3p36ZmoL3dXN5+lK4E/AfsCzJvjzul/zOby4eS/u8d4BLwCOa96v/1Jb8t7aHN9FzTrr9qxz53zqZeDjm3VvAP4APG+cz/AOYyx/FPA16s0rN1GfgvB36s0f7wDmz9S57mt0XlHK3caUlCRJ0gyzD5okSVLLGNAkSZJaxoAmSZLUMgY0SZKkljGgSZIktYwBTZIkqWUMaJIkSS1jQJMkSWoZA5okSVLLGNAkSZJaxoAmSZLUMgY0SZKkljGgac6JiC0jokTEgmnY9kXNtted6m1LktRhQJMkSWoZA5okSVLLGNA0a0TE+hHxrYj4R0TcEhE3RMTFEfGLiHhdU2YB8Ptmlac1lyM7r4u6trV6RLwzIn7ZbO+miLg+Ik6NiF0iYrmefe8QEQV4cDPrHz3b3rK7XEQcOMYxrNtbl65lm0bEIRFxWUTc2tTnwog4LCJeMJn3TpI0uywz0xWQBhERjwKOA1YGzgV+DtwOrA08FVgL+Dbwa+BmYBvgyub7jqu7vt4G+CJwOXABcCKwOvAE4FPACyJiq1LKLU35C4DvAC8GVgQOA27o2t4/J3l8WwO/AuYBZwInAEs3x/Xc5usjJrMPSdLsYUDTbPFeajj7SCll7+4FEbE8sBlAKeVTEXEiNYCdU0rZYYztnQY8sZRyYs+2VgV+CDwLeCfw2Wa7xwLHNi1lKwI7l1IumooDa3yYGs5eVUr5Xk+dVgE2nMJ9SZJazkucmi0e2Ex/2buglHJTKeUPE9lYKeXs3nDWzP8P8I7m25dMuJbDW9LxXdevrpKkucsWNM0WJwPPAb4aEbsDx5RSbp7MBiNiaWBL4EnAmsDyQDQvgEdMZvsTdDLwSOB7EfEJ4MRSym334v4lSS1iQNNs8VngKcAzqP3KFkfEmcAfgB+WUk6ZyMYiYn3gJ8BGSyi28pB1HcauwKOBZzevmyLidGAB8L1Sytn3Yl0kSTPMS5yaFUopi0opzwQeD+wGHAU8nNo37eSI+PIEN/ljajj7OfUmg9WA+5RSAlh2yip+T33PuVLKP4HHAVsBewMnAZtQ+6b9NSJ2mcY6SZJaxhY0zSpNS9kpABGxDLAdcBCwU0T8uJTy+yWsTrPeBtTWqn8BL+xzKXH9SVTx1ma60hjLHzzGfEophdpitqCp53LADsCXgU80x/f3SdRNkjRL2IKmWauUclsp5cfAkc2sxzbTTkga6x+Q+zXThWP083rVEnY73rYvb6YbjLH8uUvY9t2UUm4upewP/Jl6rj560HUlSbObAU2zQkTsFBH36LQfEWtQLw0CXNxML2um60fEvD6bO486htrGnQFmu7b3fOA9S6hKZ9tj9V07GbgeeGREvLpn2y+hDt1xDxGxc0Ss02f+BtzVondx73JJ0twU9aqK1G4RcQbwGOAfwF+oIWh1YAvq3ZdHA9t0WsQi4hRqcDsXOJU6eO3VpZQPNsv/D3gXcAfwR2Ah9a7NTYC9gI8ANH3SuuvxNmA/6iC1vwH+0yz6bCnl3KbMu4EvNPNPoLaqbUi9S3Mv4KPAxaWUdbu2ey2wCnAOcDZwEzCfemPEMsBBpZTXTvydkyTNRgY0zQoR8Vzq5cHNqU8PWIXah+wC6hMEflBKWdxVfh3gk9RO96tTQ86doSgiAngdsBM1mN0OnAXsV0o5pHmsU7+AthTwAepl0IcCnUdCbVVKWdBV7jXUAPhI6mXRU5v6XEANmb0B7ZXA1tQBd+dTB8P9J/A34OvAEcWTVZJGhgFNkiSpZeyDJkmS1DIGNEmSpJYxoEmSJLWMAU2SJKllDGiSJEkt46Oe1HrbL/jWjN5qfPiWO8b4pUbHJW9/xIz+PNbZ71x/HjNkn6NOndGf/fu2fpw/e40MW9AkSZJaxoAmSZLUMgY0SZKkljGgSZIktYwBTZIkqWUMaJIkSS1jQJNmUESUiDhwwLIHRsSUD3MQEVs29dhhqret9puuz9UoiYg9mnNo3Zmuy70pItZtjnuPma7LXGRAkyYpItaJiNubX1RbznR9RlVX0Ox+/TciToyI10eEY2jNQV3haMsxlu/gPyCajRyoVpq8HYBbgGuB1wELZrAugoOBI6n/gK4NvAE4AJgPfHwG6yVJA7MFTZqEplVmB+AI4DvAiyNipRmtlE4rpRxcSjmolPIJ4EnAjcD7ImLpGa6bJA3EgCZNztOA9YCDmtcKwEt7C0XERhHx64i4MSKuiYjvRcQD+m0wIpaLiM9GxMKIuCkiTo6IZ41VgYjYICJ+EBFXRsQtEXFBROweEfP6lH1BRPwpIm6OiEsj4uPAPcrNJaWUfwJnA6sAq3fmD/q+RcSCiLgoItaLiBwR10fEvyPiSxExr/l5fSEirmh+Xr+OiAf11qNZ/+Cu/Z3X7O8+XWU+3VyOe3if9R/eLNunZ/4rI+KEiLih+Xz9ISKe2Wf9CX2u5qquS6KPaN7vhc35cFJEPKlP+aUi4m0RcWrz/l4fEadFxDv6bH7Z8bbZbO/DEfHH5rNwa0RcGBGfi4gVe8re2T+0uUx/dtdn9fV96rp0RHw0Ii5u9v/niPjfGKOPXESsFRFfj4jLmnpc0nyW7/FPZkQ8JSKOaz47V0bEfsD/G/Bt1xC8xClNzo7AP4HflFJuj4hTmnnf7BSIiPWAPwL3AfYFLgOeD/x6jG3+ANiO2ir3W+ChwOHAP3oLRsRmwFHAVcB+wL+AxwO7AY8Btu8q+0LgMOBCYE/gduol2ecOc+CzRRO4HgTcQb0MPaH3rbFiU/53wAeArYF3ALcCGwJLA3sBDwbeQw3rW3XV4cHAScBKwFeoP4NnAHsAm0XE80spBfhus/1XNXXp9upmelDXdj8F7AL8DPhQU49XAL+OiBeXUn7Stf7An6sRcRC1ZfVTwMrA+4CfR8R6pZTr4M4W8kOAF1PP4T2bdR5FfS/3neg2qb8HdgZ+TH3/bwG2AN4LPJb6uej1VuD+1N8rNwJvBg6IiPNKKX/sKrcf8BbgaOBzwAOAr1I/b3fThLUTgKB2AbgE2KjZ1xMjYotSyuKm7BOon/3rmmO7DngZXZ9FTT0DmjSk5r/MFwH7l1Jub2Z/B9gvIh5eSjmvmbc3sCrw1M4v04j4MvWX8//0bPNZ1F/83yylvKFr/h+A7j+2Hd+k/mJ9Qinlxmbe1yLiTOCLEbFVKeX3US/tfZEaSJ5QSvl3s92vAX+ezPvQQitGxGrUPzwPogaYBwKHllJubsoM9L51bXM1YK9Syheb7/dvwvh7gcNLKS/uFGz+qO8cERuUUs5pZn+C2nq3TSnlN828L0fEV6l/ULcHDiul/CUizgBeSVdAa7b5SuCsUsqZzbzHNce2Ryllz66y+wLHA1+IiJ+WUsoQn6tR8E9guyYYExFnU0PTy4H9mzIvo4azbwFv6JRtyve7AjXINm8B5pdSbupa7ysRcR6wW0RsXko5sWe7awGPLKVc32z3UOAi4G3U4EhEbET9LP0SeH4p5Y5m/o+AM/rUtRMuH9u0MneO6yhqiH8V8O1m9heo59OTSykXNOW+AhzbZ7uaIl7ilIb3v9RLmt3/Rf6Q2qryOrjzl/jzgRO7/9NtfoF/ps82t2umn+2eWUr5KXBu97yI2BjYGPg+sHxErNZ5cVfrXOdS16bUsPKtTjhrtnsdd/3hmCv2ogbRfwGnAS+h/qHZESb8vnXczj3fp+Oof7S+0mc+wPrN/pYCEnBKVzjrrivAC7vmfRd4SEQ8uWvek6mX0r/bNe/lQAEO7jmG+wK/oLbmrd+U3a6Zjvu5GiH7dgcuoBPIH9Y1r/Me79JTlk4Amug2S3UTQEQsExGrNj+3o5sij++z3QM74azZxhXUn1t3XZ/XTP+vu26llLOoN83cKSLuCzwH+ClwW8/n53hqK90zm7IPAJ5I/Ufkgq7t3koNbpomBjRpeK+jXjq4MSIeFhEPo7aUHQ+8pmm1egC1n8Y5fdb/W595DwFuAy7os+zsnu83bKZ7UwNJ96vzR/eBXdtlAvWYzb5K/ePyXOCjwCJgTWBxs3wi71vHFaWUW3rmXdtMLx5j/v2a6erUz8BfeytaSrmcernoIV2zv08NhK/qmvcq6iXa73fN25AaEC/ocxx79BzHRD5Xc1XvWG93u7RbSrmm+fL+XbPXBy4rpVw94D4G2SYR8fKIOBW4CbiG+jNb0Cy+73jbbVzTs931mmm/wN077+HUv/9v4Z6fnauol/RH8XdHq3iJUxpCRDyCencgwPljFNsGOH0aq9H5B+sz1D5F/Sycxv231XmllN81X/8yIs6ithR8jHpJcJj37fa+pZa8bKhx10op/4yI3wIvjYh3NbNfChzdBLqOpZp9P5t7ho+OvwxTh1mmc6lwhTGWr9BTrmPQn9tEBvEdd5sR8SJq0D4BeDu1T+ot1MuYB9K/4WRKP2Nd+/gOdViafv4z5LY1RQxo0nBe10x3oF4O6PW1psyRwA3ABn3KPLLPvAupwe5h3PO/3g17vu8Ew8VdgWQsnU7Cg9ZjziilHBERvwHe3fT5msj7NhWuAv5Ln/c5IuZT7y7t7cT9XWBb6mWooLbM9nbIPp/6WflH96WnMUzkczXbdFqXNqD2v+rVOb6Lhtj2ecDzIuL+3V0DJulVwM3A1t390CJim0lu96Jm+ghq/8puj+j5/gJq8FxmgHOg+/3tNad/d8w0L3FKE9Rcunw1tU/Rd0opP+59AT+n9ju6b/P15hGxRdc2gnq3Xq8jmun7e/a5Hff8JXs69RLDTtF/WIflum6XP436n/qOEXH/rjIrUy9zzHUfo9499yEm9r5NWtMf6GfA4yNiq57FH2qmvR31f0oN9q9uXjdSbyrp1mn52Ltfh/W4+zAuE/lczTa/o17GfkPvzy0i1qD2Fb2M4Vqzv0/9O/nJ5pzt3vawrVe3U8PRnWPyNb9T3j/mGoP5WTN9d/fnoelzebfw11yy/TW1lXaT3g01fePu15S9EjgReGFEPLSrzH2odyxrmtiCJk3cNtRR6b+0hDKHA6+hDnnwEeplqF81d9hdTr1xYPXelUopR0bEz4DXN0GqMxzCm6mXqx7VVbZExGuowz/8JSK+Se0nsjL1j+6LqHcHLmiGAHkP8CPgpIg4gPqHYkfg38A6Q74Xs0Ip5biIOIba4rk39Wcz7vs2hVX4ELVf3C+aO3j/QR1O4YXUDv13C1+llEURcRj1LkKod6De2FPmpIjYi/r5Wr8pfyX1UtmTqK1lD23KDvy5mm1KKddExPuBLwNnRsR3qYHsIcDrqa2P25dSbhti8z+i3sX5RuAREfFzanB+JLVlrt+QGOM5nPoZOzoivgMsTw2Rk3oUWSnlrxHxdeBNwG8i4gjq75i3AX+i3ijUfbn2rdS7MI+P+jzgM4FlqZ+b7amf2QObsu+lng/HN3dvdobZMENMI99caeI6lzd7WzS6HUlt9dixlLJv03q2D/BOan+TX1FbRq7ss+7/Uu/ueyX1MtdZ1F+Yr6DnD2kp5bSI+B/gw9Q/JGtQO6lfSL3D6s9dZX8cES+mDt+wJ/UuxwOBPwC9dxfORXtTj3PXUspbBn3fpkIp5eKoY0ntRQ2Jq1BvLtgD+GTvHYKN7wKv7fq633Y/2nQ2fye1BWY56lAPZ3BX61zHwJ+r2aaU8pWIuJDaovMO6nhz11ADyKdLKScNud0SES+j9hXbkdoSeyv18vK3htzm9yNiFeBd1N8JV1HHWvsWfW4kmaCdqP0nX08dB+1cahB7PDWg3XlJtflMbkL9nCTq77UbqJ/Lg6j/wHTKnhB18ONPAbtSA9qPqTfknDXJOmsM0f/3gtQe2y/41ox+SA/fckcfst3lkrc/YkZ/Huvsd64/jxmyz1GnzujP/n1bP86f/RCa1tOnAyt3jdmolrMPmiRJc0BELN9n3qOpXSyONpzNLl7ilCRpbtgxIl5BvZv1Kuqdl2+iXpbtfXSYWs6AJknS3HA68AJqn8RVqcO7HAXsWUr500xWTBNnQJMkaQ4opZwAPGum66GpYR80SZKkljGgSZIktYwBTZIkqWUMaJIkSS1jQJMkSWoZA5okSVLL+KgnSZKklrEFTZIkqWUMaJIkSS1jQJMkSWoZA5okSVLLGNAkSZJaxoAmSZLUMgY0SZKkljGgSZIktYwBTZIkqWUMaJIkSS1jQJMkSWoZA5okSVLLGNAkSZJaxoAmSZLUMgY0SZKkljGgSZIktYwBTZIkqWUMaJIkSS1jQJMkSWoZA5okSVLLGNAkSZJaxoAmSZLUMgY0SZKkljGgSZIktYwBTZIkqWUMaJIkSS1jQJMkSWoZA5okSVLLGNAkSZJaxoAmSZLUMgY0SZKkljGgSZIktYwBTZIkqWUMaJIkSS1jQJMkSWoZA5okSVLLGNAkSZJaxoAmSZLUMgY0SZKkljGgSZIktYwBTZIkqWUMaJIkSS1jQJMkSWoZA5okSVLLGNAkSZJaxoAmSZLUMgY0SZKkljGgSZIktYwBTZIkqWUMaJIkSS1jQJMkSWoZA5okSVLLGNAkSZJaxoAmSZLUMgY0SZKkljGgSZIktYwBTZIkqWUMaJIkSS1jQJMkSWoZA5okSVLLGNAkSZJaxoAmSZLUMgY0SZKkljGgSZIktYwBTZIkqWUMaJIkSS1jQJMkSWoZA5okSVLLGNAkSZJa5v8DLubC0byaHtUAAAAASUVORK5CYII="
+     },
+     "metadata": {
+      "needs_background": "light"
+     }
+    }
+   ],
    "metadata": {}
   },
   {
@@ -681,11 +783,107 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "source": [
     "tbl_file_check"
    ],
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "             category                name 2021-05-02 2021-05-16 2021-05-30\n",
+       "5      Visual display          shapes.txt          ✅          ✅          ✅\n",
+       "3          Navigation          levels.txt                                 \n",
+       "4          Navigation        pathways.txt                                 \n",
+       "0               Fares  fare_leg_rules.txt                                 \n",
+       "1               Fares      fare_rules.txt                                 \n",
+       "2  Technical contacts       feed_info.txt                                 "
+      ],
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>category</th>\n",
+       "      <th>name</th>\n",
+       "      <th>2021-05-02</th>\n",
+       "      <th>2021-05-16</th>\n",
+       "      <th>2021-05-30</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>Visual display</td>\n",
+       "      <td>shapes.txt</td>\n",
+       "      <td>✅</td>\n",
+       "      <td>✅</td>\n",
+       "      <td>✅</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Navigation</td>\n",
+       "      <td>levels.txt</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Navigation</td>\n",
+       "      <td>pathways.txt</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Fares</td>\n",
+       "      <td>fare_leg_rules.txt</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Fares</td>\n",
+       "      <td>fare_rules.txt</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Technical contacts</td>\n",
+       "      <td>feed_info.txt</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 17
+    }
+   ],
    "metadata": {}
   },
   {
@@ -697,14 +895,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "source": [
     "if tbl_validation_notices.shape[0] == 0:\n",
     "    display(Markdown(\"No validation error observed in your feed.\"))\n",
     "else:    \n",
     "    display(tbl_validation_notices)"
    ],
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ],
+      "text/markdown": [
+       "No validation error observed in your feed."
+      ]
+     },
+     "metadata": {}
+    }
+   ],
    "metadata": {}
   },
   {
@@ -731,7 +942,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,

--- a/templates/report.html.jinja
+++ b/templates/report.html.jinja
@@ -38,15 +38,12 @@ Monthly GTFS Quality Reports: {{parameters["DATE_MONTH_YEAR"]}} {{parameters["AG
     </p>
 </div>
 
-{# Commented out until an ultimate resolution can be found for 
-  https://github.com/cal-itp/reports/issues/44
 <div class="my-8">
     <a class="btn responsive-prose mr-4 mb-4" href="{{ status.gtfs_schedule_url }}">
         <i class="fas fa-link mr-1 text-itp-slate-bold"></i>
         Download Feed
     </a>
 </div>
-#}
 
 <hr>
 


### PR DESCRIPTION
ongoing WIP, still need to clarify sys.argv. For generating the link base for the report urls, does @evansiroky have a preference for date parameter format. The list comprehension could be cleaned up and still need to figure out the mime type for image encoding for postmarker. As it currently is, I am able to test and successfully send emails without the embedded calitp logo. 