### PR TITLE
Properly fail html build when error occurs

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "scripts": {
     "build": "NODE_ENV=production npm-run-all html css images",
+    "html": "echo 'processing html...'; if python generate.py -eq 0; then echo 'html ready'; else echo 'html failed'; fi",
     "css": "echo 'processing css...'; npm-run-all css:clean css:sass css:postcss; echo 'css ready'",
     "css:clean": "rm -f build/css/*",
     "css:postcss": "postcss --ext min.css --dir build/css/ build/css/*.css",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "scripts": {
     "build": "NODE_ENV=production npm-run-all html css images",
-    "html": "echo 'processing html...'; if python generate.py -eq 0; then echo 'html ready'; else echo 'html failed'; fi",
+    "html": "echo 'processing html...'; if python generate.py -eq 0; then echo 'html ready'; else echo 'html failed' && exit 1; fi",
     "css": "echo 'processing css...'; npm-run-all css:clean css:sass css:postcss; echo 'css ready'",
     "css:clean": "rm -f build/css/*",
     "css:postcss": "postcss --ext min.css --dir build/css/ build/css/*.css",


### PR DESCRIPTION
This fixes the `html` command so that it'll send out a non-zero exit code when the HTML generation fails.