### PR TITLE
feat: add MJML-based template for report email

### DIFF
--- a/templates/email/report.html
+++ b/templates/email/report.html
@@ -1,0 +1,367 @@
+
+    <!doctype html>
+    <html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+      <head>
+        <title>
+
+        </title>
+        <!--[if !mso]><!-->
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <!--<![endif]-->
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <style type="text/css">
+          #outlook a { padding:0; }
+          body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+          table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+          img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+          p { display:block;margin:13px 0; }
+        </style>
+        <!--[if mso]>
+        <xml>
+        <o:OfficeDocumentSettings>
+          <o:AllowPNG/>
+          <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+        </xml>
+        <![endif]-->
+        <!--[if lte mso 11]>
+        <style type="text/css">
+          .mj-outlook-group-fix { width:100% !important; }
+        </style>
+        <![endif]-->
+
+      <!--[if !mso]><!-->
+        <link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@400;800" rel="stylesheet" type="text/css">
+<link href="https://fonts.googleapis.com/css2?family=Raleway:wght@700" rel="stylesheet" type="text/css">
+        <style type="text/css">
+          @import url(https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@400;800);
+@import url(https://fonts.googleapis.com/css2?family=Raleway:wght@700);
+        </style>
+      <!--<![endif]-->
+
+
+
+    <style type="text/css">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-100 { width:100% !important; max-width: 100%; }
+      }
+    </style>
+
+
+        <style type="text/css">
+
+
+
+    @media only screen and (max-width:480px) {
+      table.mj-full-width-mobile { width: 100% !important; }
+      td.mj-full-width-mobile { width: auto !important; }
+    }
+
+        </style>
+        <style type="text/css">a { color: #136C97; } .small-print a { color: inherit; }</style>
+
+      </head>
+      <body style="word-spacing:normal;background-color:#eeeeee;">
+
+
+      <div
+         style="background-color:#eeeeee;"
+      >
+
+
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+
+
+      <div  style="margin:0px auto;max-width:600px;">
+
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;padding-bottom:8px;padding-top:8px;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-left:10px;word-break:break-word;"
+                >
+
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;"
+      >
+        <tbody>
+          <tr>
+            <td  style="width:108px;">
+
+        <a
+           href="https://calitp.org" target="_blank"
+        >
+
+      <img
+         alt="Cal-ITP" height="auto" src="https://www.calitp.org/images/calitp_logo_MAIN.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:16px;" width="108"
+      />
+
+        </a>
+
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+                </td>
+              </tr>
+
+        </tbody>
+      </table>
+
+      </div>
+
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+      </div>
+
+
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+
+
+      <div  style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:600px;">
+
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-bottom:0;word-break:break-word;"
+                >
+
+      <div
+         style="font-family:Raleway, Verdana, sans-serif;font-size:16px;font-weight:bold;line-height:1.3333;text-align:left;color:#136C97;"
+      ><h2>Hello!</h2></div>
+
+                </td>
+              </tr>
+
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+
+      <div
+         style="font-family:'Nunito Sans', Verdana, sans-serif;font-size:16px;line-height:1.3333;text-align:left;color:#323A45;"
+      >Greetings from Cal-ITP. As part of our work with the GTFS feeds for agencies across the state, we prepare a monthly report with some basic statistics and validation results for your agency’s feed. <strong>You can view your report for [MM]</strong> and past months at <a href="[[URL]]">[[URL]]</a>.</div>
+
+                </td>
+              </tr>
+
+              <tr>
+                <td
+                   align="center" vertical-align="middle" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;"
+      >
+        <tr>
+          <td
+             align="center" bgcolor="#2ea8ce" role="presentation" style="border:none;border-radius:3px;cursor:auto;mso-padding-alt:10px 25px;background:#2ea8ce;" valign="middle"
+          >
+            <a
+               href="[[URL]]" style="display:inline-block;background:#2ea8ce;color:white;font-family:Raleway, Verdana, sans-serif;font-size:16px;font-weight:bold;line-height:1.3333;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;" target="_blank"
+            >
+              View Report
+            </a>
+          </td>
+        </tr>
+      </table>
+
+                </td>
+              </tr>
+
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+
+      <div
+         style="font-family:'Nunito Sans', Verdana, sans-serif;font-size:16px;line-height:1.3333;text-align:left;color:#323A45;"
+      >We are actively looking for opportunities to help transit agencies address issues with their GTFS feeds. If you would like to meet with our team to learn more about how we can help, or have any questions, please email our team at <a href="mailto:hello@calitp.org">hello@calitp.org</a>.</div>
+
+                </td>
+              </tr>
+
+              <tr>
+                <td
+                   align="center" vertical-align="middle" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;"
+      >
+        <tr>
+          <td
+             align="center" bgcolor="#f6bf16" role="presentation" style="border:none;border-radius:3px;cursor:auto;mso-padding-alt:10px 25px;background:#f6bf16;" valign="middle"
+          >
+            <a
+               href="mailto:hello@calitp.org" style="display:inline-block;background:#f6bf16;color:#136C97;font-family:Raleway, Verdana, sans-serif;font-size:16px;font-weight:bold;line-height:1.3333;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;" target="_blank"
+            >
+              Contact Us
+            </a>
+          </td>
+        </tr>
+      </table>
+
+                </td>
+              </tr>
+
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+
+      <div
+         style="font-family:'Nunito Sans', Verdana, sans-serif;font-size:16px;line-height:1.3333;text-align:left;color:#323A45;"
+      >Thanks,</div>
+
+                </td>
+              </tr>
+
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:0;padding-bottom:0;word-break:break-word;"
+                >
+
+      <div
+         style="font-family:Raleway, Verdana, sans-serif;font-size:20px;font-weight:bold;line-height:1.3333;text-align:left;color:#2EA8CE;"
+      >The Cal-ITP Team</div>
+
+                </td>
+              </tr>
+
+              <tr>
+                <td
+                   align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;"
+                >
+
+      <div
+         style="font-family:'Nunito Sans', Verdana, sans-serif;font-size:16px;line-height:1.3333;text-align:left;color:#323A45;"
+      ><a href="http://calitp.org" style="font-size: 12px; letter-spacing: .03em; text-decoration: none; font-weight: bold;">calitp.org</a></div>
+
+                </td>
+              </tr>
+
+        </tbody>
+      </table>
+
+      </div>
+
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+      </div>
+
+
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+
+
+      <div  style="margin:0px auto;max-width:600px;">
+
+        <table
+           align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"
+        >
+          <tbody>
+            <tr>
+              <td
+                 style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;"
+              >
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+
+      <div
+         class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"
+      >
+
+      <table
+         border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%"
+      >
+        <tbody>
+
+              <tr>
+                <td
+                   align="left" class="small-print" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+
+      <div
+         style="font-family:'Nunito Sans', Verdana, sans-serif;font-size:12px;line-height:1.3333;text-align:left;color:#5D707C;"
+      >Visit <a href="http://camobilitymarketplace.org/">CAMobilityMarketplace.org</a> for a catalog of code-compliant products and services for TransitProviders.</div>
+
+                </td>
+              </tr>
+
+              <tr>
+                <td
+                   align="left" class="small-print" style="font-size:0px;padding:10px 25px;word-break:break-word;"
+                >
+
+      <div
+         style="font-family:'Nunito Sans', Verdana, sans-serif;font-size:12px;line-height:1.3333;text-align:left;color:#2EA8CE;"
+      >Subscribe to our <a href="https://lp.constantcontactpages.com/su/eLbtFoE/calitp?source_id=a41b99cd-7f28-4be8-a286-f9e75fc7bbce&source_type=em&c=">Mobility Newsletter</a> for the latest Cal-ITP and Caltrans&nbsp;updates.</div>
+
+                </td>
+              </tr>
+
+        </tbody>
+      </table>
+
+      </div>
+
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+      </div>
+
+
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+
+
+      </div>
+
+      </body>
+    </html>

--- a/templates/email/report.html
+++ b/templates/email/report.html
@@ -327,7 +327,7 @@
 
       <div
          style="font-family:'Nunito Sans', Verdana, sans-serif;font-size:12px;line-height:1.3333;text-align:left;color:#5D707C;"
-      >Visit <a href="http://camobilitymarketplace.org/">CAMobilityMarketplace.org</a> for a catalog of code-compliant products and services for TransitProviders.</div>
+      >Visit <a href="http://camobilitymarketplace.org/">CAMobilityMarketplace.org</a> for a catalog of code-compliant products and services for Transit&nbsp;Providers.</div>
 
                 </td>
               </tr>

--- a/templates/email/report.mjml
+++ b/templates/email/report.mjml
@@ -31,7 +31,7 @@
     </mj-section>
     <mj-section>
       <mj-column>
-        <mj-text css-class="small-print" font-size="12px" color="#5D707C">Visit <a href="http://camobilitymarketplace.org/">CAMobilityMarketplace.org</a> for a catalog of code-compliant products and services for TransitProviders.</mj-text>
+        <mj-text css-class="small-print" font-size="12px" color="#5D707C">Visit <a href="http://camobilitymarketplace.org/">CAMobilityMarketplace.org</a> for a catalog of code-compliant products and services for Transit&nbsp;Providers.</mj-text>
         <mj-text css-class="small-print" font-size="12px" color="#2EA8CE">Subscribe to our <a href="https://lp.constantcontactpages.com/su/eLbtFoE/calitp?source_id=a41b99cd-7f28-4be8-a286-f9e75fc7bbce&source_type=em&c=">Mobility Newsletter</a> for the latest Cal-ITP and Caltrans&nbsp;updates.</mj-text>
       </mj-column>
     </mj-section>

--- a/templates/email/report.mjml
+++ b/templates/email/report.mjml
@@ -1,0 +1,39 @@
+<mjml>
+  <mj-head>
+    <mj-font name="Nunito Sans" href="https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@400;800" />
+    <mj-font name="Raleway" href="https://fonts.googleapis.com/css2?family=Raleway:wght@700" />
+    <mj-attributes>
+      <mj-all color="#323A45" font-family="'Nunito Sans', Verdana, sans-serif" font-size="16px" line-height="1.3333" />
+      <mj-button background-color="#2ea8ce" color="white" font-weight="bold" font-family="Raleway, Verdana, sans-serif" />
+      <mj-class name="display-font" font-family="Raleway, Verdana, sans-serif" font-weight="bold" />
+    </mj-attributes>
+    <mj-style> a { color: #136C97; } .small-print a { color: inherit; } </mj-style>
+  </mj-head>
+  <mj-body background-color="#eee">
+    <mj-section padding-bottom="8px" padding-top="8px">
+      <mj-column>
+        <mj-image padding-left="10px" src="https://www.calitp.org/images/calitp_logo_MAIN.png" href="https://calitp.org" width="108" alt="Cal-ITP" align="left" />
+      </mj-column>
+    </mj-section>
+    <mj-section background-color="#fff">
+      <mj-column>
+        <mj-text padding-bottom="0" color="#136C97" mj-class="display-font">
+          <h2>Hello!</h2>
+        </mj-text>
+        <mj-text>Greetings from Cal-ITP. As part of our work with the GTFS feeds for agencies across the state, we prepare a monthly report with some basic statistics and validation results for your agency’s feed. <strong>You can view your report for [MM]</strong> and past months at <a href="[[URL]]">[[URL]]</a>.</mj-text>
+        <mj-button href="[[URL]]">View Report</mj-button>
+        <mj-text>We are actively looking for opportunities to help transit agencies address issues with their GTFS feeds. If you would like to meet with our team to learn more about how we can help, or have any questions, please email our team at <a href="mailto:hello@calitp.org">hello@calitp.org</a>.</mj-text>
+        <mj-button background-color="#f6bf16" color="#136C97" href="mailto:hello@calitp.org">Contact Us</mj-button>
+        <mj-text>Thanks,</mj-text>
+        <mj-text padding-top="0" color="#2EA8CE" mj-class="display-font" font-size="20px" padding-bottom="0">The Cal-ITP Team</mj-text>
+        <mj-text padding-top="0"><a href="http://calitp.org" style="font-size: 12px; letter-spacing: .03em; text-decoration: none; font-weight: bold;">calitp.org</a></mj-text>
+      </mj-column>
+    </mj-section>
+    <mj-section>
+      <mj-column>
+        <mj-text css-class="small-print" font-size="12px" color="#5D707C">Visit <a href="http://camobilitymarketplace.org/">CAMobilityMarketplace.org</a> for a catalog of code-compliant products and services for TransitProviders.</mj-text>
+        <mj-text css-class="small-print" font-size="12px" color="#2EA8CE">Subscribe to our <a href="https://lp.constantcontactpages.com/su/eLbtFoE/calitp?source_id=a41b99cd-7f28-4be8-a286-f9e75fc7bbce&source_type=em&c=">Mobility Newsletter</a> for the latest Cal-ITP and Caltrans&nbsp;updates.</mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>


### PR DESCRIPTION
This adds an [MJML](https://mjml.io/) template for a new report email, as well its compiled output. I've stored both in `/templates/email` for now; feel free to move them elsewhere.

To be replaced by a script before sending this out are the `[MM]` text, `[[URL]]` text, and a few instances of ``[[URL]]`` in the links in the code.

Not yet tested in email clients, though MJML should help!

![index-desktop](https://user-images.githubusercontent.com/1154929/146287378-647f4ac0-629b-4531-814b-b1821b31100f.png)
![index-mobile](https://user-images.githubusercontent.com/1154929/146287382-358d71c8-3c1f-44b3-b2cd-8464346dd2dd.png)
