### PR TITLE
Email reports generation

### DIFF
--- a/reports/3_generate_report_emails.py
+++ b/reports/3_generate_report_emails.py
@@ -83,7 +83,7 @@ else:
 # Prompt user on whether to continue (if show_prompt specified) ----
 if config.getboolean("show_prompt"):
     result = input(f"""
-You are about to email the following addresses: {", ".join(all_emails)}
+You are about to email the following {all_emails.count()} addresses: {", ".join(all_emails)}
 To continue, type yes.""")
     
     if result != "yes":

--- a/reports/3_generate_report_emails.py
+++ b/reports/3_generate_report_emails.py
@@ -102,7 +102,3 @@ for emails, html_messages in all_emails_list:
     email.send()
 except BaseException as err:
         print(f"failure to print to {emails}: {err}")
-    
-
-
-    

--- a/reports/3_generate_report_emails.py
+++ b/reports/3_generate_report_emails.py
@@ -70,7 +70,7 @@ html_messages = report_emails.report_url.apply(_generate_template)
 all_emails = report_emails.main_email
 all_emails_list = list(zip(all_emails,html_messages))
 
-
+print("Using server token (Sandbox is f38...): " + config["postmark_server_token"])
 # +
 # Double check if we're on development that it is going to the sandbox ----
 if config.getboolean("is_development"):

--- a/reports/3_generate_report_emails.py
+++ b/reports/3_generate_report_emails.py
@@ -97,4 +97,9 @@ for emails, html_messages in all_emails_list:
         Subject=config['email_subject'],
         HtmlBody=html_messages,
         )
+    try:
     email.send()
+    except BaseException as err :
+        print(f"failure to print to {emails}: {err}")
+
+    

--- a/reports/3_generate_report_emails.py
+++ b/reports/3_generate_report_emails.py
@@ -97,7 +97,7 @@ for emails, html_messages in all_emails_list:
         HtmlBody=html_messages,
         )
     print(f"sending to emails: {emails}")
-try:
-    email.send()
-except BaseException as err:
-    print(f"failure to print to {emails}: {err}")
+    try:
+        email.send()
+    except BaseException as err:
+        print(f"failure to print to {emails}: {err}")

--- a/reports/3_generate_report_emails.py
+++ b/reports/3_generate_report_emails.py
@@ -97,6 +97,7 @@ for emails, html_messages in all_emails_list:
         Subject=config['email_subject'],
         HtmlBody=html_messages,
         )
+    print(f"sending to emails: {emails}")
     try:
     email.send()
     except BaseException as err :

--- a/reports/3_generate_report_emails.py
+++ b/reports/3_generate_report_emails.py
@@ -100,7 +100,9 @@ for emails, html_messages in all_emails_list:
     print(f"sending to emails: {emails}")
     try:
     email.send()
-    except BaseException as err :
+except BaseException as err:
         print(f"failure to print to {emails}: {err}")
+    
+
 
     

--- a/reports/3_generate_report_emails.py
+++ b/reports/3_generate_report_emails.py
@@ -84,8 +84,7 @@ else:
 if config.getboolean("show_prompt"):
     result = input(f"""
 You are about to email the following {all_emails.count()} addresses: {", ".join(all_emails)}
-To continue, type yes.""")
-    
+To continue, type yes.""") 
     if result != "yes":
         raise Exception("Need yes to continue")
     
@@ -98,7 +97,7 @@ for emails, html_messages in all_emails_list:
         HtmlBody=html_messages,
         )
     print(f"sending to emails: {emails}")
-    try:
+try:
     email.send()
 except BaseException as err:
-        print(f"failure to print to {emails}: {err}")
+    print(f"failure to print to {emails}: {err}")


### PR DESCRIPTION
Updates to the python script that generates the monthly report emails for Calitp. Currently use a Config.ini file that contains all the variables that are used to update the mjml email body. Most recently added additional checks to ensure that the person running the script has several fail safes before accidentally sending emails to clients using the production server token. Logging count of emails as a sanity check to make sure the list count matches the production csv file (avoid duplicates/deletions etc). Added additional logging to catch is any of the emails generate a hard bounce back in postmark and continue sending emails. 
This scrip can always be improved especially since there has been discussion to try and streamline the existing workflow 