### PR TITLE
Add postmark Link tracking in config file 

### DIFF
--- a/reports/3_generate_report_emails.py
+++ b/reports/3_generate_report_emails.py
@@ -95,6 +95,8 @@ for emails, html_messages in all_emails_list:
         To=emails,
         Subject=config['email_subject'],
         HtmlBody=html_messages,
+        TrackOpens=config['track_opens'],
+        TrackLinks=config['track_links']
         )
     print(f"sending to emails: {emails}")
     try:

--- a/reports/config-example.ini
+++ b/reports/config-example.ini
@@ -7,6 +7,8 @@ email_from = hello@calitp.org
 email_subject = GTFS Quality Reports from Cal-ITP
 email_template = ../templates/email/report.mjml
 is_development = True
+track_links = HtmlAndText
+track_opens = True
 
 [development]
 email_csv_path = test_emails.csv


### PR DESCRIPTION
As part of https://github.com/cal-itp/reports/issues/96, we need to manually override the postmarker link tracking settings for it to be visible within the postmark UI. I put both settings in the config file to be read into the API call with the other config settings 