### PR TITLE
update workflow to avoid error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
 
     # copy in reports ----
 
-    - uses: google-github-actions/setup-gcloud@master
+    - uses: google-github-actions/setup-gcloud@v0
       with:
         service_account_key: ${{ secrets.GCP_SA_KEY }}
         export_default_credentials: true


### PR DESCRIPTION
github is chaning the naming standards for their github actions away from master, to have the code pass we need to change it to main. 