### PR TITLE
bug: updated the url to have new url address

### DIFF
--- a/templates/index.html.jinja
+++ b/templates/index.html.jinja
@@ -91,7 +91,7 @@
 
         <div class="flex flex-col md:flex-row items-baseline mt-4 mb-12">
             <a class="btn responsive-prose mr-2 mb-2"
-                href="https://dot.ca.gov/programs/rail-and-mass-transportation/gtfs/gtfs-data-quality"
+                href="https://dot.ca.gov/cal-itp/california-minimum-general-transit-feed-specification-gtfs-guidelines"
                 target="_blank">
                     Read more
                     <i class="fas fa-external-link-alt ml-1"></i>


### PR DESCRIPTION
Updated the url from https://dot.ca.gov/programs/rail-and-mass-transportation/gtfs/gtfs-data-quality to https://dot.ca.gov/cal-itp/california-minimum-general-transit-feed-specification-gtfs-guidelines`. Verified in local development that it connects correctly. I am pushing this to main rather than development as this is a bug that is already exposed to end users. 