### PR TITLE
Revert "chore(deps): bump numpy from 1.20.3 to 1.21.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,7 @@ nbformat==5.1.3
 nest-asyncio==1.5.1
 nodeenv==1.6.0
 notebook==6.4.3
-numpy==1.21.0
+numpy==1.20.3
 oauthlib==3.1.1
 packaging==20.9
 pandas==1.1.4


### PR DESCRIPTION
Accidently applied chore to main rather than development branch 