### PR TITLE
Issue #43: Upgrades papermill, removes black, and suppresses warnings

### DIFF
--- a/reports/Makefile
+++ b/reports/Makefile
@@ -24,7 +24,7 @@ outputs/%/parameters.json: generate_parameters
 
 
 outputs/%/index.ipynb: report.ipynb outputs/%/parameters.json
-	papermill -f $(dir $@)parameters.json $< $@
+	papermill --log-level=ERROR -f $(dir $@)parameters.json $< $@
 
 
 outputs/%/index.html: outputs/%/index.ipynb

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ argon2-cffi==21.1.0
 async-timeout==3.0.1
 attrs==21.2.0
 backcall==0.2.0
-black==21.8b0
 bleach==4.1.0
 cachetools==4.2.2
 calitp==0.0.15
@@ -70,7 +69,7 @@ packaging==20.9
 pandas==1.1.4
 pandas-gbq==0.14.1
 pandocfilters==1.4.3
-papermill==2.3.3
+papermill==2.3.4
 parso==0.8.2
 pathspec==0.9.0
 pexpect==4.8.0


### PR DESCRIPTION
# Description

This removes a number of the warnings that make it more difficult to debug by upgrading papermill, removing black, and only piping errors.

Resolves # 43

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

This has been tested locally. It should be tested by another dev.

