### PR TITLE
updated script to use full month instead of abv

### DIFF
--- a/website/generate.py
+++ b/website/generate.py
@@ -40,13 +40,13 @@ env.filters = {**env.filters, "nl2br": nl2br, "month_name": month_name}
 
 
 def friendly_month(x): 
-    return datetime.strptime(x, "%Y-%m-%d").strftime("%b")
+    return datetime.strptime(x, "%Y-%m-%d").strftime("%B")
 
 def friendly_month_day(x): 
-    return datetime.strptime(x, "%Y-%m-%d").strftime("%b %d")
+    return datetime.strptime(x, "%Y-%m-%d").strftime("%B %d")
 
 def friendly_month_year(x):
-    return datetime.strptime(x, "%Y-%m-%d").strftime("%b %Y")
+    return datetime.strptime(x, "%Y-%m-%d").strftime("%B %Y")
 
 def friendly_month_day_year_from_string(x):
     return datetime.strptime(x,'%Y%m%d').strftime('%m-%d-%Y')
@@ -91,7 +91,7 @@ for year in index_data["reports"]:
                 p_basedir / f"{year['year']}/{month['month']:02d}"
         )
 
-        DATE_MONTH_YEAR = friendly_month_year(f"{year['year']}-{month['month']:02d}-01")
+        DATE_MONTH_YEAR = friendly_month_day(f"{year['year']}-{month['month']:02d}-01")
 
         month_html = month_template.render(**global_data, year=year, month=month, DATE_MONTH_YEAR=DATE_MONTH_YEAR)
 
@@ -127,6 +127,9 @@ def fetch_report_data(report_dir):
     parameters["START_MONTH_DAY"] = friendly_month_day(parameters["DATE_START"])
     parameters["END_MONTH_DAY"] = friendly_month_day(parameters["DATE_END"])
     report_data["parameters"] = parameters
+
+    #print(report_data)
+    #print(DATE_MONTH_YEAR)
 
     return report_data
 

--- a/website/generate.py
+++ b/website/generate.py
@@ -91,7 +91,7 @@ for year in index_data["reports"]:
                 p_basedir / f"{year['year']}/{month['month']:02d}"
         )
 
-        DATE_MONTH_YEAR = friendly_month_day(f"{year['year']}-{month['month']:02d}-01")
+        DATE_MONTH_YEAR = friendly_month_year(f"{year['year']}-{month['month']:02d}-01")
 
         month_html = month_template.render(**global_data, year=year, month=month, DATE_MONTH_YEAR=DATE_MONTH_YEAR)
 
@@ -128,8 +128,6 @@ def fetch_report_data(report_dir):
     parameters["END_MONTH_DAY"] = friendly_month_day(parameters["DATE_END"])
     report_data["parameters"] = parameters
 
-    #print(report_data)
-    #print(DATE_MONTH_YEAR)
 
     return report_data
 


### PR DESCRIPTION
# Description

Updated generate.py to use the locales full name instead of the abbreviated name within the strptime() Format Code

Resolves # [https://github.com/cal-itp/reports/issues/150]

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
tested locally, also tested that longer months did not warp the ui of the reports generated.

## Screenshots (optional)
