### PR TITLE
use a separate alias for the "manually" deployed preview site

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
       if: ${{ github.event_name == 'push' }}
       run: |
         npm install netlify-cli
-        netlify deploy --site=cal-itp-reports --dir=./website/build --alias=development-build
+        netlify deploy --site=cal-itp-reports --dir=./website/build --alias=test
       env:
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
     - name: Deploy production to Netlify


### PR DESCRIPTION
It looks like we can't re-use the same alias for manual deploys as the continuous deploys were using, so we need to use a new one.

https://github.com/netlify/cli/issues/1984#issuecomment-879764391