### PR TITLE
Issue #172: Remove need to have extra line in CSV email file

### DIFF
--- a/reports/generate_report_emails.py
+++ b/reports/generate_report_emails.py
@@ -40,7 +40,7 @@ REPORT_LINK_BASE = f'https://reports.calitp.org/gtfs_schedule/{PUBLISH_DATE_YEAR
 # -
 # TODO: need to ensure that the test_emails.csv and production email sheet use the
 #       same column names
-tbl_report_emails = pd.read_csv(config["email_csv_path"], skiprows=1)
+tbl_report_emails = pd.read_csv(config["email_csv_path"])
 tbl_report_emails.columns = tbl_report_emails.columns.str.lower()
 tbl_report_emails.columns = tbl_report_emails.columns.str.replace(' ','_')
 report_emails = (

--- a/reports/test_emails.csv
+++ b/reports/test_emails.csv
@@ -1,5 +1,4 @@
-﻿test_email.csv,,,,
-Title,First Name,Last Name,Main Email,ITP_ID
-Test,general,test,natalya.d@jarv.us,1
-Boss,personal ,test,nkgdiaz@gmail.com ,2
-Howdy,test,test,test@email.com ,3
+﻿Title,First Name,Last Name,Main Email,ITP_ID
+Developer,Aaron,Couch,aaron.c@jarv.us,4
+Data Services,Olivia,Ramacier,olivia@compiler.la,4
+Product Manager,Eric,Dasmalchi,eric.dasmalchi@dot.ca.gov,4


### PR DESCRIPTION
# Description

Description in ticket. Removes skipping first line in CSV and updates test emails.

Resolves #179

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
This was tested locally. Running `python generate_report_emails.py development` with a properly configured `config.ini` file produces emails with the new test csv file.