### PR TITLE
fix: removes image copying from website generation

### DIFF
--- a/website/generate.py
+++ b/website/generate.py
@@ -158,10 +158,6 @@ for year, month, entry in iter_report_entries(index_data["reports"]):
     p_final.parent.mkdir(parents=True, exist_ok=True)
     p_final.write_text(report_html)
 
-
-    for image in p_report_inputs.glob("*.png"):
-        shutil.copy(str(image), p_final.parent / image.name)
-
 ################################################################################
 # render all reports
 


### PR DESCRIPTION
# Description

This removes a build step that was deprecated in #196 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

Running `npm run build` still runs reports.
