### PR TITLE
Substitute service_date for acivity_date in reports generation

### DIFF
--- a/reports/generate_reports_data.py
+++ b/reports/generate_reports_data.py
@@ -123,7 +123,6 @@ def generate_daily_service_hours(itp_id: int, date_start, date_end):
             _.n_stop_times,
             _.service_day_type,
         )
-        >> rename(service_date=_.activity_date)
         >> rename(last_arrival_ts=_.last_arrival_sec)
         >> rename(calitp_itp_id=_.organization_itp_id)
         >> rename(first_departure_ts=_.first_departure_sec)

--- a/reports/generate_reports_data.py
+++ b/reports/generate_reports_data.py
@@ -110,10 +110,10 @@ def generate_daily_service_hours(itp_id: int, date_start, date_end):
     service_hours = (
         tbls.mart_gtfs_quality.fct_daily_reports_site_organization_scheduled_service_summary()
         >> filtr(_.organization_itp_id == itp_id)
-        >> filtr(_.service_date >= date_start)
-        >> filtr(_.service_date <= date_end)
+        >> filtr(_.activity_date >= date_start)
+        >> filtr(_.activity_date <= date_end)
         >> select(
-            _.service_date,
+            _.activity_date,
             _.n_routes,
             _.organization_itp_id,
             _.n_trips,
@@ -123,6 +123,7 @@ def generate_daily_service_hours(itp_id: int, date_start, date_end):
             _.n_stop_times,
             _.service_day_type,
         )
+        >> rename(service_date=_.activity_date)
         >> rename(last_arrival_ts=_.last_arrival_sec)
         >> rename(calitp_itp_id=_.organization_itp_id)
         >> rename(first_departure_ts=_.first_departure_sec)

--- a/templates/report.html.jinja
+++ b/templates/report.html.jinja
@@ -139,7 +139,7 @@
 
             {% set weekday_hours = daily_service_hours|selectattr('weekday', '==', 'Weekday')|list %}
             <div class="hours-chart"
-                 data-dates="{{ getJsonForAttribute(weekday_hours, 'service_date')|trim }}"
+                 data-dates="{{ getJsonForAttribute(weekday_hours, 'activity_date')|trim }}"
                  data-hours="{{ getJsonForAttribute(weekday_hours, 'ttl_service_hours')|trim }}"
                  data-color="#136C97">
             </div>
@@ -154,7 +154,7 @@
 
             {% set sat_hours = daily_service_hours|selectattr('weekday', '==', 'Saturday')|list %}
             <div class="hours-chart"
-                 data-dates="{{ getJsonForAttribute(sat_hours, 'service_date')|trim }}"
+                 data-dates="{{ getJsonForAttribute(sat_hours, 'activity_date')|trim }}"
                  data-hours="{{ getJsonForAttribute(sat_hours, 'ttl_service_hours')|trim }}"
                  data-color="#F6BF16">
             </div>
@@ -167,7 +167,7 @@
 
             {% set sun_hours = daily_service_hours|selectattr('weekday', '==', 'Sunday')|list %}
             <div class="hours-chart"
-                 data-dates="{{ getJsonForAttribute(sun_hours, 'service_date')|trim }}"
+                 data-dates="{{ getJsonForAttribute(sun_hours, 'activity_date')|trim }}"
                  data-hours="{{ getJsonForAttribute(sun_hours, 'ttl_service_hours')|trim }}"
                  data-color="#5B559C">
             </div>

--- a/tests/schemas/schema_2_daily_service_hours.json
+++ b/tests/schemas/schema_2_daily_service_hours.json
@@ -5,7 +5,7 @@
     {
       "type": "object",
       "properties": {
-        "service_date": {
+        "activity_date": {
           "type": "integer"
         },
         "n_routes": {
@@ -48,7 +48,7 @@
         }
       },
       "required": [
-        "service_date",
+        "activity_date",
         "n_routes",
         "calitp_itp_id",
         "n_trips",


### PR DESCRIPTION
# Description

Recently we decided to utilize `activity_date` instead of `service_date` for analysis purposes (see [Analyst POC Table: aggregated GTFS schedule service hours by date type #2275](https://github.com/cal-itp/data-infra/pull/2275))

This PR changes the reports generation to use the `activity_date` column

## Type of change

- [x] New feature

## How has this been tested?
locally using dev reports generation workflow
