### PR TITLE
Handle URL struct columns with JSON

### DIFF
--- a/reports/generate_index_report.py
+++ b/reports/generate_index_report.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 from pathlib import Path
 
 from calitp.tables import tbls
@@ -29,9 +30,10 @@ df_report_index = ids_with_feeds >> mutate(
         lambda d: f"{d.year}/{d.month:02d}/{d.organization_itp_id}", axis=1
     ),
     report_path=_.apply(lambda d: f"{d.dir_path}/index.html", axis=1),
+    feeds=_.feeds.apply(json.loads),
 )
 
-cols_to_keep = ["agency_name", "itp_id", "report_path"]
+cols_to_keep = ["agency_name", "itp_id", "report_path", "feeds"]
 
 index_report = (
     df_report_index


### PR DESCRIPTION
# Description

PR #2338 in the data infra repo added dataset URL information to `idx_monthly_reports_site` for the reports site as array structs, which was causing problems when generating the index with `generate_index_report.py`.

To address this, #2415 in the data-infra repo addresses this by changing the structs in `idx_monthly_reports_site` to JSON strings, and then this PR takes those JSON strings and turns them into JSON.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature

## How has this been tested?
In a notebook
