### PR TITLE
update to python 3.9 in last place

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - uses: actions/setup-node@v2
       with:
         node-version: '14'


### PR DESCRIPTION
# Description

I missed that we had a mismatch in python versions between PR and main actions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

## Screenshots (optional)
