### PR TITLE
try to work around mutate resulting in nans

### DIFF
--- a/reports/generate_reports_data.py
+++ b/reports/generate_reports_data.py
@@ -9,7 +9,7 @@ import typer
 from calitp_data_analysis.sql import get_engine  # type: ignore
 from siuba import _, arrange, collect  # type: ignore
 from siuba import filter as filtr  # type: ignore
-from siuba import if_else, mutate, pipe, rename, select, spread  # type: ignore
+from siuba import mutate, pipe, rename, select, spread  # type: ignore
 from siuba.sql import LazyTbl  # type: ignore
 from tqdm import tqdm
 
@@ -149,8 +149,14 @@ def generate_file_check(itp_id: int, publish_date):
         >> rename(success=_.file_present)
         >> rename(name=_.filename)
         >> rename(category=_.reason)
+    )
+
+    file_check.success = file_check.success.apply(lambda v: "✅" if v else "")
+    # replacing this in mutate call
+    #     success=if_else(_.success == True, "✅", ""),  # noqa: E712
+    file_check = (
+        file_check
         >> mutate(
-            success=if_else(_.success == True, "✅", ""),  # noqa: E712
             date_checked=_.date_checked.astype(str),
         )
         >> spread(_.date_checked, _.success)

--- a/tests/schemas/schema_1_feed_info.json
+++ b/tests/schemas/schema_1_feed_info.json
@@ -39,7 +39,7 @@
         "no_service_days_ct": {
            "anyOf": [
             {
-              "type": "integer"
+              "type": "number"
             },
             {
               "type": "null"


### PR DESCRIPTION
# Description

We noticed that the file presence data does not seem to show in the reports data; all pages show all files missing (e.g. shapes.txt). @charlie-costanzo tracked it down to something in the mutate call that populates the checkboxes. I added a small workaround that uses pandas directly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

## Screenshots (optional)
dataframe after fix
![image](https://github.com/cal-itp/reports/assets/4305366/5dd1a87a-ded5-4c7a-9268-4ab7ecd9cf77)
