### PR TITLE
use reports_order field instead of hardcoded value

### DIFF
--- a/reports/generate_reports_data.py
+++ b/reports/generate_reports_data.py
@@ -155,7 +155,6 @@ def _guideline_check():
 
 
 def generate_guideline_check(itp_id: int, publish_date):
-
     guideline_check = (
         _guideline_check()
         >> filtr(_.organization_itp_id == itp_id)

--- a/reports/generate_reports_data.py
+++ b/reports/generate_reports_data.py
@@ -148,32 +148,25 @@ def _guideline_check():
             _.check,
             _.reports_status,
             _.is_manual,
+            _.reports_order,
         )
         >> collect()
     )
 
 
 def generate_guideline_check(itp_id: int, publish_date):
-    importance = [
-        "A GTFS Schedule feed is listed",
-        "GTFS schedule feed downloads successfully",
-        "No errors in MobilityData GTFS Schedule Validator",
-        "GTFS Schedule feed is published at a stable URI (permalink) from which it can be “fetched” automatically by trip-planning applications*",
-        "Includes an open license that allows commercial use of GTFS Schedule feed*",
-        "GTFS Schedule feed ingested by Google Maps and/or a combination of Apple Maps, Transit App, Bing Maps, Moovit or local Open Trip Planner services*",
-    ]
 
     guideline_check = (
         _guideline_check()
         >> filtr(_.organization_itp_id == itp_id)
         >> filtr(_.publish_date == publish_date)
-        >> select(_.date_checked, _.check, _.reports_status, _.is_manual)
+        >> select(_.date_checked, _.check, _.reports_status, _.is_manual, _.reports_order)
         >> mutate(
             date_checked=_.date_checked.astype(str),
             check=np.where(_.is_manual, _.check + "*", _.check),
         )
         >> spread(_.date_checked, _.reports_status)
-        >> arrange(_.check.apply(importance.index))
+        >> arrange(_.reports_order)
         >> pipe(_.fillna(""))
     )
 

--- a/reports/generate_reports_data.py
+++ b/reports/generate_reports_data.py
@@ -160,7 +160,9 @@ def generate_guideline_check(itp_id: int, publish_date):
         _guideline_check()
         >> filtr(_.organization_itp_id == itp_id)
         >> filtr(_.publish_date == publish_date)
-        >> select(_.date_checked, _.check, _.reports_status, _.is_manual, _.reports_order)
+        >> select(
+            _.date_checked, _.check, _.reports_status, _.is_manual, _.reports_order
+        )
         >> mutate(
             date_checked=_.date_checked.astype(str),
             check=np.where(_.is_manual, _.check + "*", _.check),

--- a/templates/report.html.jinja
+++ b/templates/report.html.jinja
@@ -310,10 +310,10 @@
                         </th>
 
                         <th class="whitespace-nowrap">
-                            {{ guideline_check["columns"][2] }}
+                            {{ guideline_check["columns"][3] }}
                         </th>
                         <th class="whitespace-nowrap">
-                            {{ guideline_check["columns"][3] }}
+                            {{ guideline_check["columns"][4] }}
                         </th>
                     </tr>
                 </thead>
@@ -324,10 +324,10 @@
                                 {{ row[0] }}
                             </td>
                             <td>
-                                {{ show_check_status(row[2]) }}
+                                {{ show_check_status(row[3]) }}
                             </td>
                             <td>
-                                {{ show_check_status(row[3]) }}
+                                {{ show_check_status(row[4]) }}
                             </td>
                         </tr>
                     {% endfor %}

--- a/tests/schemas/schema_4_guideline_check.json
+++ b/tests/schemas/schema_4_guideline_check.json
@@ -55,21 +55,7 @@
               "type": "boolean"
             },
             {
-              "type": "string"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        {
-          "type": "array",
-          "items": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "boolean"
+              "type": "integer"
             },
             {
               "type": "string"
@@ -89,21 +75,7 @@
               "type": "boolean"
             },
             {
-              "type": "string"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        {
-          "type": "array",
-          "items": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "boolean"
+              "type": "integer"
             },
             {
               "type": "string"
@@ -123,6 +95,9 @@
               "type": "boolean"
             },
             {
+              "type": "integer"
+            },
+            {
               "type": "string"
             },
             {
@@ -138,6 +113,49 @@
             },
             {
               "type": "boolean"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "type": "array",
+          "items": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "type": "array",
+          "items": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "integer"
             },
             {
               "type": "string"


### PR DESCRIPTION
# Description

Utilize new "reports_order" field rather than hardcoded "importance" value.

Resolves #259

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
Manually reviewed JSON output and checked local reports site (see screenshot). Confirmed that order matches the previous hardcoded order.

## Screenshots (optional)
![Screen Shot 2023-06-27 at 11 01 49 AM](https://github.com/cal-itp/reports/assets/3301353/0b40366c-6fa9-42ff-be74-d5a92e5e66f7)

