### PR TITLE
Build development data in GH action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,8 +48,8 @@ jobs:
       run: |
         make data
       working-directory: reports
-      with:
-        service_account_key: ${{ secrets.GCP_SA_KEY }}
+      env:
+        GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
 
     # build ----
     - name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
 
     # Run data ----
     - name: Run report data
+      if: ${{ github.ref == 'refs/heads/main' }}
       run: |
         make parameters
         make data
@@ -51,7 +52,7 @@ jobs:
     - name: Copy production report data
       if: ${{ startsWith(github.ref, 'refs/tags/') }}
       run: |
-        gsutil -m rsync -r reports/outputs/ gs://gtfs-data/report_gtfs_schedule/
+        gsutil -m rsync -r gs://gtfs-data-test/report_gtfs_schedule/ gs://gtfs-data/report_gtfs_schedule/
 
     # build ----
     - name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,9 @@ jobs:
     - name: Run report data
       run: |
         make data
+      working-directory: reports
+      with:
+        service_account_key: ${{ secrets.GCP_SA_KEY }}
 
     # build ----
     - name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,22 +34,16 @@ jobs:
         export_default_credentials: true
 
     # copy data ----
-    - name: Copy development report data
-      if: ${{ github.ref == 'refs/heads/main' }}
-      run: |
-        gsutil -m rsync -r gs://gtfs-data-test/report_gtfs_schedule/ reports/outputs/
-    - name: Copy production report data
-      if: ${{ startsWith(github.ref, 'refs/tags/') }}
-      run: |
-        gsutil -m rsync -r gs://gtfs-data/report_gtfs_schedule/ reports/outputs/
 
-    # Re-run data ----
+    # Run data ----
     - name: Run report data
       run: |
+        make parameters
         make data
       working-directory: reports
       env:
-        GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+        service_account_key: ${{ secrets.GCP_SA_KEY }}
+        export_default_credentials: true
 
     # build ----
     - name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,11 @@ jobs:
       run: |
         gsutil -m rsync -r gs://gtfs-data/report_gtfs_schedule/ reports/outputs/
 
+    # Re-run data ----
+    - name: Run report data
+      run: |
+        make data
+
     # build ----
     - name: Build
       run: npm run build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,17 +33,25 @@ jobs:
         service_account_key: ${{ secrets.GCP_SA_KEY }}
         export_default_credentials: true
 
-    # copy data ----
-
     # Run data ----
     - name: Run report data
       run: |
         make parameters
         make data
       working-directory: reports
-      env:
+      with:
         service_account_key: ${{ secrets.GCP_SA_KEY }}
         export_default_credentials: true
+
+    # copy data ----
+    - name: Copy development report data
+      if: ${{ github.ref == 'refs/heads/main' }}
+      run: |
+        gsutil -m rsync -r reports/outputs/ gs://gtfs-data-test/report_gtfs_schedule/
+    - name: Copy production report data
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
+      run: |
+        gsutil -m rsync -r reports/outputs/ gs://gtfs-data/report_gtfs_schedule/
 
     # build ----
     - name: Build
@@ -51,7 +59,6 @@ jobs:
       working-directory: website
 
     # deploy ----
-
     - name: Deploy development to Netlify
       if: ${{ github.ref == 'refs/heads/main' }}
       run: |


### PR DESCRIPTION
# Description

Recently, we hit an actions failure due to a new feature referencing data not available in development (and therefore CI) without a rebuild of development data. This PR adds a re-build of the data on merges with main.

Resolves #268 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

## Screenshots (optional)
