### PR TITLE
add Christian to CODEOWNERS, fix email script column name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # repo owners
 
-* @edasmalchi @owades
+* @edasmalchi @owades @csuyat-dot

--- a/reports/generate_report_emails.py
+++ b/reports/generate_report_emails.py
@@ -71,7 +71,7 @@ def _generate_template(report_url):
 
 
 html_messages = report_emails.report_url.apply(_generate_template)
-all_emails = report_emails.main_email
+all_emails = report_emails.email
 all_emails_list = list(zip(all_emails, html_messages))
 
 print("Using server token (Sandbox is f38...): " + config["postmark_server_token"])

--- a/reports/test_emails.csv
+++ b/reports/test_emails.csv
@@ -1,3 +1,3 @@
-First Name,Last Name,Main Email,Company name,ITP_ID
+First Name,Last Name,Email,Company name,ITP_ID
 Olivia,Ramacier,olivia@compiler.la,Los Angeles County Metropolitan Transportation Authority,182
 Eric,Dasmalchi,eric.dasmalchi@dot.ca.gov,Los Angeles County Metropolitan Transportation Authority,182


### PR DESCRIPTION
# Description

Change the email script to match column names from Hubspot exports.

Also, add @csuyat-dot to CODEOWNERS.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?

emails sent successfully
