### PR TITLE
Fixing incorrect Median VP Latency Graph in the monthly report website

### DIFF
--- a/reports/generate_reports_data.py
+++ b/reports/generate_reports_data.py
@@ -195,24 +195,29 @@ def generate_ave_median_tu_age(itp_id: int, date_start, date_end):
 def _median_vp_age():
     return query_sql(
         """
-SELECT
-  -- mas.base64_url, #Issues are here, this is producing orgs without proper cal-itp ids
-  organization_name,
-  organization_itp_id as calitp_itp_id,
-  DATETIME(DATE_TRUNC(mas.dt, DAY)) AS service_date,
-  AVG(mas.median_vehicle_message_age) AS avg_median_vehicle_message_age
-
-FROM `mart_gtfs_quality.fct_daily_vehicle_positions_message_age_summary` mas
-
-LEFT JOIN `mart_transit_database.dim_gtfs_datasets` dgd
-  ON mas.base64_url = dgd.base64_url
-LEFT JOIN `mart_transit_database.dim_provider_gtfs_data` dpgd
-  ON dgd.key = dpgd.vehicle_positions_gtfs_dataset_key
-
-WHERE mas.dt < DATE_TRUNC(CURRENT_DATE('America/Los_Angeles'), DAY)
-AND organization_itp_id is not null
-
-GROUP BY 1, 2, 3
+SELECT 
+    organization_name,
+    organization_itp_id AS calitp_itp_id,
+    dt AS service_date,
+    AVG(pls.median_vehicle_message_age) AS avg_median_vehicle_message_age
+FROM 
+    `cal-itp-data-infra.mart_gtfs_quality.fct_daily_vehicle_positions_latency_statistics` pls
+LEFT JOIN 
+    `cal-itp-data-infra.mart_transit_database.dim_provider_gtfs_data` dpg
+    ON pls.gtfs_dataset_key = dpg.vehicle_positions_gtfs_dataset_key
+    AND dt BETWEEN DATE(_valid_from) AND DATE(_valid_to)
+WHERE 
+    organization_itp_id IS NOT NULL
+    AND public_customer_facing_or_regional_subfeed_fixed_route = TRUE
+    AND dt < DATE_TRUNC(CURRENT_DATE('America/Los_Angeles'), DAY)
+GROUP BY 
+    organization_name, 
+    organization_itp_id, 
+    dt
+ORDER BY 
+    organization_name, 
+    organization_itp_id, 
+    dt;
 """,
         as_df=True,
     )


### PR DESCRIPTION
# Description

The median vehicle position latency displayed on the report website is showing incorrectly inflated numbers. This issue is caused by referencing the wrong table.

**Current Table Used:**
`fct_daily_vehicle_positions_message_age_summary`

**Correct Table to Use:**
`fct_daily_vehicle_positions_latency_statistics`

*Proposed Fix:**
The table used to generate the monthly median vehicle position (VP) latency graph should be updated to the correct table: `fct_daily_vehicle_positions_latency_statistics.`
In this PR, I am correcting this issue.

Resolves # 322

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

