### PR TITLE
Should allow github action to find netlify

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,18 +67,18 @@ jobs:
       run: npm run build
       working-directory: website
 
-    # deploy ----
+    # deploy ----https://docs.netlify.com/cli/get-started/.  -g is not recommended but it should be okay in this situation
     - name: Deploy development to Netlify
       if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.site_target == 'dev')}}
       run: |
-        npm install netlify-cli
+        npm install netlify-cli -g
         netlify deploy --site=cal-itp-reports --dir=./website/build --alias=test
       env:
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
     - name: Deploy production to Netlify
       if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || (github.event_name == 'workflow_dispatch' && inputs.site_target == 'prod')}}
       run: |
-        npm install netlify-cli
+        npm install netlify-cli -g
         netlify deploy --site=cal-itp-reports --dir=./website/build --prod
       env:
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}


### PR DESCRIPTION
# Description

The error message was "netlify: command not found".  This should install it globally so if it installed correctly, it can be found*!

*Though the recommend way to use netlify in this situation is  --save-dev but we are moving on from netlify soon anyways.

Possibly Resolves #327 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
Not tested properly yet!

Did a little testing locally.  I might be able to add `... npx netlify` to the beginning and that might work as well. Or possibly `npm install netlify-cli --save-dev`

I don't know why this stopped working!  But to be fair we haven't locked down many of the package versions.

## Screenshots (optional)
