### PR TITLE
Replaces old reports site URL with new URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Why reports?
 
-[reports.calitp.org](https://reports.calitp.org/) exists to provide a snapshot of transit service information and transit data quality information for agencies across California. It also serves to connect agencies and other stakeholders with technical assistance from Cal-ITP and Caltrans.
+[reports.dds.dot.ca.gov](https://reports.dds.dot.ca.gov/) exists to provide a snapshot of transit service information and transit data quality information for agencies across California. It also serves to connect agencies and other stakeholders with technical assistance from Cal-ITP and Caltrans.
 
 ## When and how to generate reports
 

--- a/reports/generate_report_emails.py
+++ b/reports/generate_report_emails.py
@@ -37,9 +37,7 @@ postmark = PostmarkClient(server_token=SERVER_TOKEN)
 PUBLISH_DATE_YEAR = config["year"]
 PUBLISH_DATE_MONTH = config["month"]
 
-REPORT_LINK_BASE = (
-    f"https://reports.dds.dot.ca.gov/gtfs_schedule/{PUBLISH_DATE_YEAR}/{PUBLISH_DATE_MONTH}"
-)
+REPORT_LINK_BASE = f"https://reports.dds.dot.ca.gov/gtfs_schedule/{PUBLISH_DATE_YEAR}/{PUBLISH_DATE_MONTH}"
 # -
 # TODO: need to ensure that the test_emails.csv and production email sheet use the
 #       same column names

--- a/reports/generate_report_emails.py
+++ b/reports/generate_report_emails.py
@@ -38,7 +38,7 @@ PUBLISH_DATE_YEAR = config["year"]
 PUBLISH_DATE_MONTH = config["month"]
 
 REPORT_LINK_BASE = (
-    f"https://reports.calitp.org/gtfs_schedule/{PUBLISH_DATE_YEAR}/{PUBLISH_DATE_MONTH}"
+    f"https://reports.dds.dot.ca.gov/gtfs_schedule/{PUBLISH_DATE_YEAR}/{PUBLISH_DATE_MONTH}"
 )
 # -
 # TODO: need to ensure that the test_emails.csv and production email sheet use the

--- a/templates/email/report.mjml
+++ b/templates/email/report.mjml
@@ -22,7 +22,7 @@
         </mj-text>
         <mj-text>Greetings from Cal-ITP. As part of our work with the GTFS feeds for agencies across the state, we prepare a monthly report with some basic statistics and validation results for your agency’s feed. <strong>You can view your report for {{month_name}}</strong> at <a href="{{url}}?utm_campaign=reports&amp;utm_source=reports-mailer&amp;utm_medium=email&amp;utm_content=report-link">{{url}}</a>.</mj-text>
         <mj-button href="{{url}}?utm_campaign=reports&amp;utm_source=reports-mailer&amp;utm_medium=email&amp;utm_content=report-button">View Report</mj-button>
-        <mj-text>All previous reports are available at <a href="https://reports.calitp.org/?utm_campaign=reports&amp;utm_source=reports-mailer&amp;utm_medium=email&amp;utm_content=all-reports-link">https://reports.calitp.org/</a>.</mj-text>
+        <mj-text>All previous reports are available at <a href="https://reports.dds.dot.ca.gov/?utm_campaign=reports&amp;utm_source=reports-mailer&amp;utm_medium=email&amp;utm_content=all-reports-link">https://reports.dds.dot.ca.gov/</a>.</mj-text>
         <mj-text>If you have any questions about your monthly report, recent changes, or would like technical assistance with your GTFS feed(s), please contact us at <a href="mailto:hello@calitp.org?subject=Feedback - Monthly GTFS Report">hello@calitp.org</a>.</mj-text>
         <mj-text>Thanks,</mj-text>
         <mj-spacer height="10px" /> <mj-text padding-top="3px" padding-bottom="10px" line-height="1.2" color="#2EA8CE" mj-class="display-font" font-size="20px">The Cal-ITP Team</mj-text>

--- a/website/generate.py
+++ b/website/generate.py
@@ -106,7 +106,7 @@ def friendly_month_day_year_from_string(x):
 
 
 global_data = {
-    # "SITE_DOMAIN": "https://reports.calitp.org",
+    # "SITE_DOMAIN": "https://reports.dds.dot.ca.gov",
     "SITE_PATH": "",
     "SITE_DOMAIN": "",
     # "SITE_PATH": "",


### PR DESCRIPTION
# Description

Reports email template and associated scripts still showed `reports.calitp.org`. Was replaced with `reports.dds.dot.ca.gov`. Had quick meeting with @edasmalchi to confirm which code/scripts should be updated.

Resolves #358

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## How has this been tested?
Per `readme` instructions, sent test email to myself. Confirmed:
- email script still runs
- all email hyperlinks display the new URL
- all hyperlinks click through the reports site. 

## Screenshots (optional)
<img width="785" height="490" alt="image" src="https://github.com/user-attachments/assets/df56c1f5-361d-48a9-9239-046f84a694aa" />
